### PR TITLE
Various Improvements

### DIFF
--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -150,6 +150,13 @@ namespace UVOCBot.Commands
             builder.AddField("TestInlineFieldName2", "TestInlineFieldValue2", true);
             await ctx.RespondAsync(embed: builder.Build()).ConfigureAwait(false);
         }
+
+        [Command("throw-exception")]
+        [RequireOwner]
+        public Task ThrowExceptionCommand(CommandContext ctx)
+        {
+            throw new Exception();
+        }
 #endif
 
         /// <summary>

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -81,7 +81,7 @@ namespace UVOCBot.Commands
             }
 
             // Find or create the guild settings record
-            GuildSettingsDTO settings = await GetGuildSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildSettingsDTO settings = await DbApi.GetGuildSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
 
             // Check that a bonk channel has been set
             if (settings.BonkChannelId is null)
@@ -123,7 +123,7 @@ namespace UVOCBot.Commands
                 return;
             }
 
-            GuildSettingsDTO settings = await GetGuildSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildSettingsDTO settings = await DbApi.GetGuildSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
             settings.BonkChannelId = bonkChannel.Id;
             await DbApi.UpdateGuildSettings(settings.GuildId, settings).ConfigureAwait(false);
 
@@ -170,22 +170,6 @@ namespace UVOCBot.Commands
         {
             Permissions permissions = channel.PermissionsFor(member);
             return (permissions & permission) != 0;
-        }
-
-        private async Task<GuildSettingsDTO> GetGuildSettingsAsync(ulong id)
-        {
-            GuildSettingsDTO settings;
-            try
-            {
-                settings = await DbApi.GetGuildSetting(id).ConfigureAwait(false);
-            }
-            catch
-            {
-                settings = new GuildSettingsDTO(id);
-                await DbApi.CreateGuildSettings(settings).ConfigureAwait(false);
-            }
-
-            return settings;
         }
     }
 }

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -76,7 +76,7 @@ namespace UVOCBot.Commands
             // Check that UVOCBot can move members out of the current channel
             if (!CheckPermission(ctx.Member.VoiceState.Channel, ctx.Guild.CurrentMember, Permissions.MoveMembers))
             {
-                await ctx.RespondAsync($"{Program.NAME} does not have permissions to move members from your current channel").ConfigureAwait(false);
+                await ctx.RespondAsync($"{ctx.Guild.CurrentMember.DisplayName} does not have permissions to move members from your current channel").ConfigureAwait(false);
                 return;
             }
 
@@ -101,7 +101,7 @@ namespace UVOCBot.Commands
             // Check that UVOCBot can move members into the bonk channel
             if (!CheckPermission(bonkChannel, ctx.Guild.CurrentMember, Permissions.MoveMembers))
             {
-                await ctx.RespondAsync($"{Program.NAME} does not have permissions to move members to the bonk channel").ConfigureAwait(false);
+                await ctx.RespondAsync($"{ctx.Guild.CurrentMember.DisplayName} does not have permissions to move members to the bonk channel").ConfigureAwait(false);
                 return;
             }
 

--- a/UVOCBot/Commands/PlanetsideModule.cs
+++ b/UVOCBot/Commands/PlanetsideModule.cs
@@ -10,8 +10,6 @@ using UVOCBot.Services;
 
 namespace UVOCBot.Commands
 {
-    [Group("planetside")]
-    [Aliases("ps2", "ps")]
     [Description("Commands that provide information about PlanetSide 2")]
     public class PlanetsideModule : BaseCommandModule
     {
@@ -20,8 +18,8 @@ namespace UVOCBot.Commands
         public IFisuApiService FisuApi { get; set; }
         public ICensusQueryFactory CensusFactory { get; set; }
 
-        [Command("server")]
-        [Aliases("s", "world")]
+        [Command("population")]
+        [Aliases("pop", "server-status")]
         [Description("Gets the status and population of a server")]
         public async Task GetWorldStatusCommand(CommandContext ctx, [Description("The server to get the status of")] string server)
         {

--- a/UVOCBot/Commands/TeamsModule.cs
+++ b/UVOCBot/Commands/TeamsModule.cs
@@ -12,8 +12,6 @@ using UVOCBot.Extensions;
 
 namespace UVOCBot.Commands
 {
-    [Group("teams")]
-    [Aliases("team")]
     [Description("Commands that help with generating team lists")]
     [RequireGuild]
     public class TeamsModule : BaseCommandModule

--- a/UVOCBot/Commands/TwitterModule.cs
+++ b/UVOCBot/Commands/TwitterModule.cs
@@ -175,7 +175,7 @@ namespace UVOCBot.Commands
 
             if ((channelPerms & Permissions.SendMessages) == 0 || (channelPerms & Permissions.AccessChannels) == 0)
             {
-                await ctx.RespondAsync($"{Program.NAME} needs permission to send messages to {channel.Mention}. Your relay channel has **not** been updated").ConfigureAwait(false);
+                await ctx.RespondAsync($"{ctx.Guild.CurrentMember.DisplayName} needs permission to send messages to {channel.Mention}. Your relay channel has **not** been updated").ConfigureAwait(false);
                 return;
             }
 

--- a/UVOCBot/Commands/TwitterModule.cs
+++ b/UVOCBot/Commands/TwitterModule.cs
@@ -48,10 +48,10 @@ namespace UVOCBot.Commands
                 return;
 
             // Find or create the guild twitter settings record
-            GuildTwitterSettingsDTO settings = await GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildTwitterSettingsDTO settings = await DbApi.GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
 
             // Find or create the twitter user record
-            TwitterUserDTO twitterUser = await GetDbTwitterUserAsync(long.Parse(user.User.Id)).ConfigureAwait(false);
+            TwitterUserDTO twitterUser = await DbApi.GetDbTwitterUserAsync(long.Parse(user.User.Id)).ConfigureAwait(false);
 
             if (!settings.TwitterUsers.Contains(twitterUser.UserId))
                 await DbApi.CreateGuildTwitterLink(settings.GuildId, twitterUser.UserId).ConfigureAwait(false);
@@ -80,7 +80,7 @@ namespace UVOCBot.Commands
             if (user is null)
                 return;
 
-            GuildTwitterSettingsDTO settings = await GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildTwitterSettingsDTO settings = await DbApi.GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
             long twitterUserId = long.Parse(user.User.Id);
 
             if (settings.TwitterUsers.Contains(twitterUserId))
@@ -102,7 +102,7 @@ namespace UVOCBot.Commands
             await ctx.TriggerTypingAsync().ConfigureAwait(false);
 
             // Find the settings record for the calling guild
-            GuildTwitterSettingsDTO settings = await GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildTwitterSettingsDTO settings = await DbApi.GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
 
             if (settings.TwitterUsers.Count == 0)
             {
@@ -143,7 +143,7 @@ namespace UVOCBot.Commands
         {
             await ctx.TriggerTypingAsync().ConfigureAwait(false);
 
-            GuildTwitterSettingsDTO settings = await GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildTwitterSettingsDTO settings = await DbApi.GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
             if (settings.RelayChannelId is null)
             {
                 await ctx.RespondAsync("A relay channel has not yet been set").ConfigureAwait(false);
@@ -179,7 +179,7 @@ namespace UVOCBot.Commands
                 return;
             }
 
-            GuildTwitterSettingsDTO settings = await GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildTwitterSettingsDTO settings = await DbApi.GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
 
             settings.RelayChannelId = channel.Id;
             await DbApi.UpdateGuildTwitterSetting(settings.GuildId, settings).ConfigureAwait(false);
@@ -193,7 +193,7 @@ namespace UVOCBot.Commands
         {
             await ctx.TriggerTypingAsync().ConfigureAwait(false);
 
-            GuildTwitterSettingsDTO settings = await GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildTwitterSettingsDTO settings = await DbApi.GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
 
             settings.IsEnabled = false;
             await DbApi.UpdateGuildTwitterSetting(settings.GuildId, settings).ConfigureAwait(false);
@@ -207,7 +207,7 @@ namespace UVOCBot.Commands
         {
             await ctx.TriggerTypingAsync().ConfigureAwait(false);
 
-            GuildTwitterSettingsDTO settings = await GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildTwitterSettingsDTO settings = await DbApi.GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
 
             settings.IsEnabled = true;
             await DbApi.UpdateGuildTwitterSetting(settings.GuildId, settings).ConfigureAwait(false);
@@ -221,7 +221,7 @@ namespace UVOCBot.Commands
         {
             await ctx.TriggerTypingAsync().ConfigureAwait(false);
 
-            GuildTwitterSettingsDTO settings = await GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
+            GuildTwitterSettingsDTO settings = await DbApi.GetGuildTwitterSettingsAsync(ctx.Guild.Id).ConfigureAwait(false);
             StringBuilder sb = new StringBuilder("Tweet relaying is ");
 
             if (settings.IsEnabled)
@@ -269,38 +269,6 @@ namespace UVOCBot.Commands
             {
                 await ctx.RespondAsync($"The Twitter user **{username}** does not exist").ConfigureAwait(false);
                 return null;
-            }
-
-            return user;
-        }
-
-        private async Task<GuildTwitterSettingsDTO> GetGuildTwitterSettingsAsync(ulong id)
-        {
-            GuildTwitterSettingsDTO settings;
-            try
-            {
-                settings = await DbApi.GetGuildTwitterSetting(id).ConfigureAwait(false);
-            }
-            catch
-            {
-                settings = new GuildTwitterSettingsDTO(id);
-                await DbApi.CreateGuildTwitterSettings(settings).ConfigureAwait(false);
-            }
-
-            return settings;
-        }
-
-        private async Task<TwitterUserDTO> GetDbTwitterUserAsync(long id)
-        {
-            TwitterUserDTO user;
-            try
-            {
-                user = await DbApi.GetTwitterUser(id).ConfigureAwait(false);
-            }
-            catch
-            {
-                user = new TwitterUserDTO(id);
-                await DbApi.CreateTwitterUser(user).ConfigureAwait(false);
             }
 
             return user;

--- a/UVOCBot/Extensions/IApiServiceExtensions.cs
+++ b/UVOCBot/Extensions/IApiServiceExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using UVOCBot.Core.Model;
+
+namespace UVOCBot.Services
+{
+    public static class IApiServiceExtensions
+    {
+        public static async Task<GuildTwitterSettingsDTO> GetGuildTwitterSettingsAsync(this IApiService service, ulong id)
+        {
+            GuildTwitterSettingsDTO settings;
+            try
+            {
+                settings = await service.GetGuildTwitterSetting(id).ConfigureAwait(false);
+            }
+            catch
+            {
+                settings = new GuildTwitterSettingsDTO(id);
+                await service.CreateGuildTwitterSettings(settings).ConfigureAwait(false);
+            }
+
+            return settings;
+        }
+
+        public static async Task<TwitterUserDTO> GetDbTwitterUserAsync(this IApiService service, long id)
+        {
+            TwitterUserDTO user;
+            try
+            {
+                user = await service.GetTwitterUser(id).ConfigureAwait(false);
+            }
+            catch
+            {
+                user = new TwitterUserDTO(id);
+                await service.CreateTwitterUser(user).ConfigureAwait(false);
+            }
+
+            return user;
+        }
+
+        public static async Task<GuildSettingsDTO> GetGuildSettingsAsync(this IApiService service, ulong id)
+        {
+            GuildSettingsDTO settings;
+            try
+            {
+                settings = await service.GetGuildSetting(id).ConfigureAwait(false);
+            }
+            catch
+            {
+                settings = new GuildSettingsDTO(id);
+                await service.CreateGuildSettings(settings).ConfigureAwait(false);
+            }
+
+            return settings;
+        }
+    }
+}

--- a/UVOCBot/Program.cs
+++ b/UVOCBot/Program.cs
@@ -39,7 +39,6 @@ namespace UVOCBot
         private const string CENSUS_API_KEY = "UVOCBOT_DBG_CENSUS_KEY";
 
         public const string PREFIX = "ub!";
-        public const string NAME = "UVOCBot";
 
         public static int Main(string[] args)
         {

--- a/UVOCBot/Program.cs
+++ b/UVOCBot/Program.cs
@@ -1,5 +1,6 @@
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Exceptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -158,6 +159,12 @@ namespace UVOCBot
                             | DiscordIntents.GuildMembers
             });
 
+            client.ClientErrored += (_, e) =>
+            {
+                Log.Error(e.Exception, "The event {event} errored", e.EventName);
+                return Task.CompletedTask;
+            };
+
             CommandsNextExtension commands = client.UseCommandsNext(new CommandsNextConfiguration
             {
                 StringPrefixes = new string[] { PREFIX },
@@ -165,6 +172,21 @@ namespace UVOCBot
             });
             commands.CommandErrored += (_, a) => { Log.Error(a.Exception, "Command {command} failed", a.Command); return Task.CompletedTask; };
             commands.RegisterCommands(Assembly.GetExecutingAssembly());
+
+            commands.CommandErrored += async (_, e) =>
+            {
+                Type exceptionType = e.Exception.GetType();
+                if (exceptionType.Equals(typeof(ArgumentException)))
+                    await e.Context.RespondAsync($"You haven't provided valid parameters. Please see `{PREFIX}help` for more information.").ConfigureAwait(false);
+                else if (exceptionType.Equals(typeof(TargetInvocationException)))
+                    await e.Context.RespondAsync("Oops! Something went wrong while running that command. Please try again.").ConfigureAwait(false);
+                else if (exceptionType.Equals(typeof(ChecksFailedException)))
+                    await e.Context.RespondAsync("You don't have the necessary permissions to perform this command. Please contact your server administrator/s.").ConfigureAwait(false);
+                else if (exceptionType.Equals(typeof(CommandNotFoundException)))
+                    await e.Context.RespondAsync($"That command doesn't exist! Please see `{PREFIX}help` for a list of available commands.").ConfigureAwait(false);
+                else
+                    await e.Context.RespondAsync("Command failed: " + e.Exception).ConfigureAwait(false);
+            };
 
             return client;
         }

--- a/UVOCBot/UVOCBot.csproj
+++ b/UVOCBot/UVOCBot.csproj
@@ -17,9 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="DaybreakGames.Census" Version="3.1.0" />
-    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00789" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00789" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-nightly-00789" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00795" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00795" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-nightly-00795" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="5.0.1" />
     <PackageReference Include="Refit" Version="5.2.4" />


### PR DESCRIPTION
This PR:
- Removes the command groups `planetside` and `teams`
- Renames the planetside server status command to `population`
- Informs the user when they have incorrectly used a command, or that command has errored
- Centralises DTO retrieval functions
- Removes the constant `Program.NAME` in favour of using guild-specific display names