### PR TITLE
Allow custom prefixes

### DIFF
--- a/UVOCBot.Api/Controllers/GuildSettingsController.cs
+++ b/UVOCBot.Api/Controllers/GuildSettingsController.cs
@@ -90,7 +90,8 @@ namespace UVOCBot.Api.Controllers
             return new GuildSettingsDTO
             {
                 GuildId = settings.GuildId,
-                BonkChannelId = settings.BonkChannelId
+                BonkChannelId = settings.BonkChannelId,
+                Prefix = settings.Prefix
             };
         }
 
@@ -99,7 +100,8 @@ namespace UVOCBot.Api.Controllers
             return new GuildSettings
             {
                 GuildId = dto.GuildId,
-                BonkChannelId = dto.BonkChannelId
+                BonkChannelId = dto.BonkChannelId,
+                Prefix = dto.Prefix
             };
         }
 

--- a/UVOCBot.Api/Controllers/GuildSettingsController.cs
+++ b/UVOCBot.Api/Controllers/GuildSettingsController.cs
@@ -21,9 +21,12 @@ namespace UVOCBot.Api.Controllers
 
         // GET: api/GuildSettings
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<GuildSettingsDTO>>> GetGuildSettings()
+        public async Task<ActionResult<IEnumerable<GuildSettingsDTO>>> GetGuildSettings([FromQuery] bool hasPrefix)
         {
-            return (await _context.GuildSettings.ToListAsync().ConfigureAwait(false)).ConvertAll(e => ToDTO(e));
+            if (hasPrefix)
+                return (await _context.GuildSettings.Where(s => !string.IsNullOrEmpty(s.Prefix)).ToListAsync().ConfigureAwait(false)).ConvertAll(e => ToDTO(e));
+            else
+                return (await _context.GuildSettings.ToListAsync().ConfigureAwait(false)).ConvertAll(e => ToDTO(e));
         }
 
         // GET: api/GuildSettings/5

--- a/UVOCBot.Api/Migrations/20210209001228_CustomPrefixes.Designer.cs
+++ b/UVOCBot.Api/Migrations/20210209001228_CustomPrefixes.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UVOCBot.Api;
 
-namespace UVOCBot.Migrations
+namespace UVOCBot.Api.Migrations
 {
     [DbContext(typeof(BotContext))]
-    partial class BotContextModelSnapshot : ModelSnapshot
+    [Migration("20210209001228_CustomPrefixes")]
+    partial class CustomPrefixes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/UVOCBot.Api/Migrations/20210209001228_CustomPrefixes.cs
+++ b/UVOCBot.Api/Migrations/20210209001228_CustomPrefixes.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace UVOCBot.Api.Migrations
+{
+    public partial class CustomPrefixes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<ulong>(
+                name: "BonkChannelId",
+                table: "GuildSettings",
+                type: "bigint unsigned",
+                nullable: true,
+                oldClrType: typeof(ulong),
+                oldType: "bigint unsigned");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Prefix",
+                table: "GuildSettings",
+                type: "longtext",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Prefix",
+                table: "GuildSettings");
+
+            migrationBuilder.AlterColumn<ulong>(
+                name: "BonkChannelId",
+                table: "GuildSettings",
+                type: "bigint unsigned",
+                nullable: false,
+                defaultValue: 0ul,
+                oldClrType: typeof(ulong),
+                oldType: "bigint unsigned",
+                oldNullable: true);
+        }
+    }
+}

--- a/UVOCBot.Api/Model/GuildSettings.cs
+++ b/UVOCBot.Api/Model/GuildSettings.cs
@@ -17,5 +17,10 @@ namespace UVOCBot.Api.Model
         /// The channel to send users to when the bonk command is used
         /// </summary>
         public ulong? BonkChannelId { get; set; }
+
+        /// <summary>
+        /// The prefix used to access bot commands
+        /// </summary>
+        public string Prefix { get; set; }
     }
 }

--- a/UVOCBot.Core/Model/GuildSettingsDTO.cs
+++ b/UVOCBot.Core/Model/GuildSettingsDTO.cs
@@ -12,6 +12,11 @@
         /// </summary>
         public ulong? BonkChannelId { get; set; }
 
+        /// <summary>
+        /// The prefix used to access bot commands
+        /// </summary>
+        public string Prefix { get; set; }
+
         public GuildSettingsDTO()
         {
         }

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -88,7 +88,7 @@ namespace UVOCBot.Commands
             // Check that a bonk channel has been set
             if (settings.BonkChannelId is null)
             {
-                await ctx.RespondAsync($"You haven't yet setup a target voice channel for the bonk command. Please use {Program.DEFAULT_PREFIX}bonk <channel>").ConfigureAwait(false);
+                await ctx.RespondAsync($"You haven't yet setup a target voice channel for the bonk command. Please use {IPrefixService.DEFAULT_PREFIX}bonk <channel>").ConfigureAwait(false);
                 return;
             }
 
@@ -96,7 +96,7 @@ namespace UVOCBot.Commands
             DiscordChannel bonkChannel = ctx.Guild.GetChannel((ulong)settings.BonkChannelId);
             if (bonkChannel == default)
             {
-                await ctx.RespondAsync($"The bonk voice chat no longer exists. Please reset it using {Program.DEFAULT_PREFIX}bonk <channel>").ConfigureAwait(false);
+                await ctx.RespondAsync($"The bonk voice chat no longer exists. Please reset it using {IPrefixService.DEFAULT_PREFIX}bonk <channel>").ConfigureAwait(false);
                 return;
             }
 

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -19,6 +19,7 @@ namespace UVOCBot.Commands
             "\r\n- The command groups `planetside` and `teams` have been removed. All commands contained in those groups are now top-level";
 
         public IApiService DbApi { get; set; }
+        public IPrefixService PrefixService { get; set; }
 
         public IOptions<GeneralOptions> GOptions { get; set; }
         public GeneralOptions GeneralOptions => GOptions.Value;
@@ -55,6 +56,25 @@ namespace UVOCBot.Commands
             builder.AddField("Release Notes", RELEASE_NOTES);
 
             await ctx.RespondAsync(embed: builder.Build()).ConfigureAwait(false);
+        }
+        [Command("prefix")]
+        [Description("Removes your custom prefix")]
+        [RequireGuild]
+        [RequireUserPermissions(Permissions.ManageGuild)]
+        public async Task PrefixCommand(CommandContext ctx)
+        {
+            await PrefixService.RemovePrefixAsync(ctx.Guild.Id).ConfigureAwait(false);
+            await ctx.RespondAsync($"Your prefix has been unset. You can trigger commands with `{GeneralOptions.CommandPrefix}`").ConfigureAwait(false);
+        }
+
+        [Command("prefix")]
+        [Description("Lets you set a custom prefix with which to trigger commands")]
+        [RequireGuild]
+        [RequireUserPermissions(Permissions.ManageGuild)]
+        public async Task PrefixCommand(CommandContext ctx, string prefix)
+        {
+            await PrefixService.UpdatePrefixAsync(ctx.Guild.Id, prefix).ConfigureAwait(false);
+            await ctx.RespondAsync($"You can now trigger commands with the prefix `{prefix}`").ConfigureAwait(false);
         }
 
         [Command("bonk")]

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -2,9 +2,11 @@
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
+using Microsoft.Extensions.Options;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using UVOCBot.Config;
 using UVOCBot.Core.Model;
 using UVOCBot.Services;
 
@@ -17,6 +19,9 @@ namespace UVOCBot.Commands
             "\r\n- The command groups `planetside` and `teams` have been removed. All commands contained in those groups are now top-level";
 
         public IApiService DbApi { get; set; }
+
+        public IOptions<GeneralOptions> GOptions { get; set; }
+        public GeneralOptions GeneralOptions => GOptions.Value;
 
         [Command("ping")]
         [Description("Pong! Tells you whether the bot is listening")]
@@ -88,7 +93,7 @@ namespace UVOCBot.Commands
             // Check that a bonk channel has been set
             if (settings.BonkChannelId is null)
             {
-                await ctx.RespondAsync($"You haven't yet setup a target voice channel for the bonk command. Please use {IPrefixService.DEFAULT_PREFIX}bonk <channel>").ConfigureAwait(false);
+                await ctx.RespondAsync($"You haven't yet setup a target voice channel for the bonk command. Please use {GeneralOptions.CommandPrefix}bonk <channel>").ConfigureAwait(false);
                 return;
             }
 
@@ -96,7 +101,7 @@ namespace UVOCBot.Commands
             DiscordChannel bonkChannel = ctx.Guild.GetChannel((ulong)settings.BonkChannelId);
             if (bonkChannel == default)
             {
-                await ctx.RespondAsync($"The bonk voice chat no longer exists. Please reset it using {IPrefixService.DEFAULT_PREFIX}bonk <channel>").ConfigureAwait(false);
+                await ctx.RespondAsync($"The bonk voice chat no longer exists. Please reset it using {GeneralOptions.CommandPrefix}bonk <channel>").ConfigureAwait(false);
                 return;
             }
 

--- a/UVOCBot/Commands/TeamsModule.cs
+++ b/UVOCBot/Commands/TeamsModule.cs
@@ -165,7 +165,7 @@ namespace UVOCBot.Commands
 
         private DiscordEmbed BuildTeamsEmbed(List<List<DiscordMember>> teams, IList<DiscordMember> captains, string embedTitle)
         {
-            // TODO: Add support for teams that will exceed longer than 6000 characters
+            // TODO: Add support for teams that will exceed longer than 6000 characters. See #22
 
             if (captains is not null && teams.Count != captains.Count)
                 throw new ArgumentOutOfRangeException(nameof(captains), "There must be the same number of captains as team members");

--- a/UVOCBot/Commands/TwitterModule.cs
+++ b/UVOCBot/Commands/TwitterModule.cs
@@ -59,7 +59,7 @@ namespace UVOCBot.Commands
             await ctx.RespondAsync($"Now relaying tweets from **{username}**!").ConfigureAwait(false);
 
             if (settings.RelayChannelId is null)
-                await ctx.RespondAsync($"You haven't set a channel to relay tweets to. Please use the `{Program.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
+                await ctx.RespondAsync($"You haven't set a channel to relay tweets to. Please use the `{IPrefixService.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
         }
 
         [Command("remove-user")]
@@ -156,7 +156,7 @@ namespace UVOCBot.Commands
                     if (channel is not null)
                         await ctx.RespondAsync($"Tweets are being relayed to {channel.Mention}").ConfigureAwait(false);
                     else
-                        await ctx.RespondAsync($"Your relay channel no longer exists. Please reset it using the `{Program.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
+                        await ctx.RespondAsync($"Your relay channel no longer exists. Please reset it using the `{IPrefixService.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
                 } catch (Exception)
                 {
                     await ctx.RespondAsync("Failed to get your relay channel. Perhaps try resetting it").ConfigureAwait(false);
@@ -238,7 +238,7 @@ namespace UVOCBot.Commands
                 if (channel is not null)
                     sb.Append("Tweets are being relayed to ").AppendLine(channel.Mention);
                 else
-                    sb.Append("Your relay channel no longer exists. Please reset it using the `").Append(Program.DEFAULT_PREFIX).AppendLine("twitter relay-channel` command");
+                    sb.Append("Your relay channel no longer exists. Please reset it using the `").Append(IPrefixService.DEFAULT_PREFIX).AppendLine("twitter relay-channel` command");
             }
 
             await ctx.RespondAsync(sb.ToString()).ConfigureAwait(false);

--- a/UVOCBot/Commands/TwitterModule.cs
+++ b/UVOCBot/Commands/TwitterModule.cs
@@ -2,6 +2,7 @@
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
+using Microsoft.Extensions.Options;
 using Serilog;
 using System;
 using System.Linq;
@@ -10,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Tweetinvi;
 using Tweetinvi.Models.V2;
+using UVOCBot.Config;
 using UVOCBot.Core.Model;
 using UVOCBot.Services;
 
@@ -28,6 +30,9 @@ namespace UVOCBot.Commands
         public ITwitterClient TwitterClient { private get; set; }
 
         public IApiService DbApi { get; set; }
+
+        public IOptions<GeneralOptions> GOptions { get; set; }
+        public GeneralOptions GeneralOptions => GOptions.Value;
 
         [Command("add-user")]
         [Aliases("add")]
@@ -59,7 +64,7 @@ namespace UVOCBot.Commands
             await ctx.RespondAsync($"Now relaying tweets from **{username}**!").ConfigureAwait(false);
 
             if (settings.RelayChannelId is null)
-                await ctx.RespondAsync($"You haven't set a channel to relay tweets to. Please use the `{IPrefixService.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
+                await ctx.RespondAsync($"You haven't set a channel to relay tweets to. Please use the `{GeneralOptions.CommandPrefix}twitter relay-channel` command").ConfigureAwait(false);
         }
 
         [Command("remove-user")]
@@ -156,7 +161,7 @@ namespace UVOCBot.Commands
                     if (channel is not null)
                         await ctx.RespondAsync($"Tweets are being relayed to {channel.Mention}").ConfigureAwait(false);
                     else
-                        await ctx.RespondAsync($"Your relay channel no longer exists. Please reset it using the `{IPrefixService.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
+                        await ctx.RespondAsync($"Your relay channel no longer exists. Please reset it using the `{GeneralOptions.CommandPrefix}twitter relay-channel` command").ConfigureAwait(false);
                 } catch (Exception)
                 {
                     await ctx.RespondAsync("Failed to get your relay channel. Perhaps try resetting it").ConfigureAwait(false);
@@ -238,7 +243,7 @@ namespace UVOCBot.Commands
                 if (channel is not null)
                     sb.Append("Tweets are being relayed to ").AppendLine(channel.Mention);
                 else
-                    sb.Append("Your relay channel no longer exists. Please reset it using the `").Append(IPrefixService.DEFAULT_PREFIX).AppendLine("twitter relay-channel` command");
+                    sb.Append("Your relay channel no longer exists. Please reset it using the `").Append(GeneralOptions.CommandPrefix).AppendLine("twitter relay-channel` command");
             }
 
             await ctx.RespondAsync(sb.ToString()).ConfigureAwait(false);

--- a/UVOCBot/Config/GeneralOptions.cs
+++ b/UVOCBot/Config/GeneralOptions.cs
@@ -7,5 +7,6 @@
         public string BotToken { get; set; }
         public string ApiEndpoint { get; set; }
         public string CensusApiKey { get; set; }
+        public string CommandPrefix { get; set; }
     }
 }

--- a/UVOCBot/Program.cs
+++ b/UVOCBot/Program.cs
@@ -31,7 +31,6 @@ namespace UVOCBot
 
     public static class Program
     {
-        public const string DEFAULT_PREFIX = "ub!";
         public static readonly DiscordColor DEFAULT_EMBED_COLOUR = DiscordColor.Purple;
 
         public static int Main(string[] args)

--- a/UVOCBot/Program.cs
+++ b/UVOCBot/Program.cs
@@ -196,7 +196,7 @@ namespace UVOCBot
                 else if (exceptionType.Equals(typeof(CommandNotFoundException)))
                     await e.Context.RespondAsync($"That command doesn't exist! Please see `{options.CommandPrefix}help` for a list of available commands.").ConfigureAwait(false);
                 else
-                    await e.Context.RespondAsync("Command failed: " + e.Exception).ConfigureAwait(false);
+                    await e.Context.RespondAsync("Command failed. Please send this to the developers:\r\n" + e.Exception).ConfigureAwait(false);
             };
 
             return client;

--- a/UVOCBot/Program.cs
+++ b/UVOCBot/Program.cs
@@ -176,7 +176,7 @@ namespace UVOCBot
 
             CommandsNextExtension commands = client.UseCommandsNext(new CommandsNextConfiguration
             {
-                StringPrefixes = new string[] { IPrefixService.DEFAULT_PREFIX },
+                StringPrefixes = new string[] { options.CommandPrefix },
                 Services = services,
                 PrefixResolver = (m) => CustomPrefixResolver(m, services.GetRequiredService<IPrefixService>())
             });
@@ -188,13 +188,13 @@ namespace UVOCBot
             {
                 Type exceptionType = e.Exception.GetType();
                 if (exceptionType.Equals(typeof(ArgumentException)))
-                    await e.Context.RespondAsync($"You haven't provided valid parameters. Please see `{IPrefixService.DEFAULT_PREFIX}help` for more information.").ConfigureAwait(false);
+                    await e.Context.RespondAsync($"You haven't provided valid parameters. Please see `{options.CommandPrefix}help` for more information.").ConfigureAwait(false);
                 else if (exceptionType.Equals(typeof(TargetInvocationException)))
                     await e.Context.RespondAsync("Oops! Something went wrong while running that command. Please try again.").ConfigureAwait(false);
                 else if (exceptionType.Equals(typeof(ChecksFailedException)))
                     await e.Context.RespondAsync("You don't have the necessary permissions to perform this command. Please contact your server administrator/s.").ConfigureAwait(false);
                 else if (exceptionType.Equals(typeof(CommandNotFoundException)))
-                    await e.Context.RespondAsync($"That command doesn't exist! Please see `{IPrefixService.DEFAULT_PREFIX}help` for a list of available commands.").ConfigureAwait(false);
+                    await e.Context.RespondAsync($"That command doesn't exist! Please see `{options.CommandPrefix}help` for a list of available commands.").ConfigureAwait(false);
                 else
                     await e.Context.RespondAsync("Command failed: " + e.Exception).ConfigureAwait(false);
             };

--- a/UVOCBot/Program.cs
+++ b/UVOCBot/Program.cs
@@ -59,9 +59,17 @@ namespace UVOCBot
                 .UseSystemd()
                 .ConfigureServices((c, services) =>
                 {
+                    // Setup the configuration bindings
                     services.Configure<TwitterOptions>(c.Configuration.GetSection(TwitterOptions.ConfigSectionName));
                     services.Configure<GeneralOptions>(c.Configuration.GetSection(GeneralOptions.ConfigSectionName));
 
+                    // Setup the API services
+                    services.AddSingleton((s) => RestService.For<IApiService>(
+                            s.GetRequiredService<IOptions<GeneralOptions>>().Value.ApiEndpoint));
+
+                    services.AddSingleton(RestService.For<IFisuApiService>("https://ps2.fisu.pw/api"));
+
+                    // Create and setup the filesystem
                     IFileSystem fileSystem = new FileSystem();
                     services.AddSingleton(fileSystem);
 
@@ -69,16 +77,12 @@ namespace UVOCBot
                     logger = SetupLogging(fileSystem);
                     Log.Information("Appdata stored in " + GetAppdataFilePath(fileSystem, null));
 
-                    // Setup 
-                    services.AddSingleton<ISettingsService>((s) => new SettingsService(s.GetService<IFileSystem>()));
+                    // Setup own services
+                    //services.AddSingleton<ISettingsService>((s) => new SettingsService(s.GetService<IFileSystem>()));
+                    services.AddSingleton<ISettingsService, SettingsService>();
+                    services.AddSingleton<IPrefixService, PrefixService>();
                     services.AddSingleton(DiscordClientFactory);
                     services.AddTransient(TwitterClientFactory);
-
-                    // Setup the API services
-                    services.AddSingleton((s) => RestService.For<IApiService>(
-                            s.GetRequiredService<IOptions<GeneralOptions>>().Value.ApiEndpoint));
-
-                    services.AddSingleton(RestService.For<IFisuApiService>("https://ps2.fisu.pw/api"));
 
                     // Setup the Census services
                     GeneralOptions generalOptions = services.BuildServiceProvider().GetRequiredService<IOptions<GeneralOptions>>().Value;
@@ -172,7 +176,7 @@ namespace UVOCBot
 
             CommandsNextExtension commands = client.UseCommandsNext(new CommandsNextConfiguration
             {
-                StringPrefixes = new string[] { DEFAULT_PREFIX },
+                StringPrefixes = new string[] { IPrefixService.DEFAULT_PREFIX },
                 Services = services
             });
             commands.CommandErrored += (_, a) => { Log.Error(a.Exception, "Command {command} failed", a.Command); return Task.CompletedTask; };
@@ -182,13 +186,13 @@ namespace UVOCBot
             {
                 Type exceptionType = e.Exception.GetType();
                 if (exceptionType.Equals(typeof(ArgumentException)))
-                    await e.Context.RespondAsync($"You haven't provided valid parameters. Please see `{DEFAULT_PREFIX}help` for more information.").ConfigureAwait(false);
+                    await e.Context.RespondAsync($"You haven't provided valid parameters. Please see `{IPrefixService.DEFAULT_PREFIX}help` for more information.").ConfigureAwait(false);
                 else if (exceptionType.Equals(typeof(TargetInvocationException)))
                     await e.Context.RespondAsync("Oops! Something went wrong while running that command. Please try again.").ConfigureAwait(false);
                 else if (exceptionType.Equals(typeof(ChecksFailedException)))
                     await e.Context.RespondAsync("You don't have the necessary permissions to perform this command. Please contact your server administrator/s.").ConfigureAwait(false);
                 else if (exceptionType.Equals(typeof(CommandNotFoundException)))
-                    await e.Context.RespondAsync($"That command doesn't exist! Please see `{DEFAULT_PREFIX}help` for a list of available commands.").ConfigureAwait(false);
+                    await e.Context.RespondAsync($"That command doesn't exist! Please see `{IPrefixService.DEFAULT_PREFIX}help` for a list of available commands.").ConfigureAwait(false);
                 else
                     await e.Context.RespondAsync("Command failed: " + e.Exception).ConfigureAwait(false);
             };

--- a/UVOCBot/Program.cs
+++ b/UVOCBot/Program.cs
@@ -177,8 +177,10 @@ namespace UVOCBot
             CommandsNextExtension commands = client.UseCommandsNext(new CommandsNextConfiguration
             {
                 StringPrefixes = new string[] { IPrefixService.DEFAULT_PREFIX },
-                Services = services
+                Services = services,
+                PrefixResolver = (m) => CustomPrefixResolver(m, services.GetRequiredService<IPrefixService>())
             });
+
             commands.CommandErrored += (_, a) => { Log.Error(a.Exception, "Command {command} failed", a.Command); return Task.CompletedTask; };
             commands.RegisterCommands(Assembly.GetExecutingAssembly());
 
@@ -198,6 +200,12 @@ namespace UVOCBot
             };
 
             return client;
+        }
+
+        private static Task<int> CustomPrefixResolver(DiscordMessage message, IPrefixService prefixService)
+        {
+            string prefix = prefixService.GetPrefix(message.Channel.GuildId);
+            return Task.FromResult(message.GetStringPrefixLength(prefix));
         }
     }
 }

--- a/UVOCBot/Services/IApiService.cs
+++ b/UVOCBot/Services/IApiService.cs
@@ -64,16 +64,16 @@ namespace UVOCBot.Services
         #region GuildSettings
 
         [Get("/guildsettings")]
-        Task<List<GuildSettingsDTO>> GetGuildSettings();
+        Task<List<GuildSettingsDTO>> GetGuildSettings([Query] bool hasPrefix = false);
 
         [Get("/guildsettings/{id}")]
         Task<GuildSettingsDTO> GetGuildSetting(ulong id);
 
         [Put("/guildsettings/{id}")]
-        Task UpdateGuildSettings(ulong id, GuildSettingsDTO user);
+        Task UpdateGuildSettings(ulong id, GuildSettingsDTO settings);
 
         [Post("/guildsettings")]
-        Task<GuildSettingsDTO> CreateGuildSettings(GuildSettingsDTO user);
+        Task<GuildSettingsDTO> CreateGuildSettings(GuildSettingsDTO settings);
 
         [Delete("/guildsettings/{id}")]
         Task DeleteGuildSettings(ulong id);

--- a/UVOCBot/Services/IPrefixService.cs
+++ b/UVOCBot/Services/IPrefixService.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading.Tasks;
+
+namespace UVOCBot.Services
+{
+    public interface IPrefixService
+    {
+        string GetPrefix(ulong guildId);
+        Task RemovePrefixAsync(ulong guildId);
+        Task SetupAsync();
+        Task UpdatePrefixAsync(ulong guildId, string newPrefix);
+    }
+}

--- a/UVOCBot/Services/IPrefixService.cs
+++ b/UVOCBot/Services/IPrefixService.cs
@@ -4,8 +4,6 @@ namespace UVOCBot.Services
 {
     public interface IPrefixService
     {
-        public const string DEFAULT_PREFIX = "ub!";
-
         string GetPrefix(ulong guildId);
         Task RemovePrefixAsync(ulong guildId);
         Task SetupAsync();

--- a/UVOCBot/Services/IPrefixService.cs
+++ b/UVOCBot/Services/IPrefixService.cs
@@ -4,6 +4,8 @@ namespace UVOCBot.Services
 {
     public interface IPrefixService
     {
+        public const string DEFAULT_PREFIX = "ub!";
+
         string GetPrefix(ulong guildId);
         Task RemovePrefixAsync(ulong guildId);
         Task SetupAsync();

--- a/UVOCBot/Services/PrefixService.cs
+++ b/UVOCBot/Services/PrefixService.cs
@@ -6,8 +6,6 @@ namespace UVOCBot.Services
 {
     public class PrefixService : IPrefixService
     {
-        public const string DEFAULT_PREFIX = "ub!";
-
         private readonly IApiService _dbApi;
         private readonly Dictionary<ulong, string> _guildPrefixPairs;
 
@@ -24,7 +22,7 @@ namespace UVOCBot.Services
             if (_guildPrefixPairs.ContainsKey(guildId))
                 return _guildPrefixPairs[guildId];
             else
-                return DEFAULT_PREFIX;
+                return IPrefixService.DEFAULT_PREFIX;
         }
 
         public async Task RemovePrefixAsync(ulong guildId)

--- a/UVOCBot/Services/PrefixService.cs
+++ b/UVOCBot/Services/PrefixService.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using UVOCBot.Core.Model;
+
+namespace UVOCBot.Services
+{
+    public class PrefixService : IPrefixService
+    {
+        public const string DEFAULT_PREFIX = "ub!";
+
+        private readonly IApiService _dbApi;
+        private readonly Dictionary<ulong, string> _guildPrefixPairs;
+
+        public bool IsSetup { get; protected set; }
+
+        public PrefixService(IApiService dbApi)
+        {
+            _dbApi = dbApi;
+            _guildPrefixPairs = new Dictionary<ulong, string>();
+        }
+
+        public string GetPrefix(ulong guildId)
+        {
+            if (_guildPrefixPairs.ContainsKey(guildId))
+                return _guildPrefixPairs[guildId];
+            else
+                return DEFAULT_PREFIX;
+        }
+
+        public async Task RemovePrefixAsync(ulong guildId)
+        {
+            _guildPrefixPairs.Remove(guildId);
+            await UpdateDbPrefix(guildId, null).ConfigureAwait(false);
+        }
+
+        public async Task SetupAsync()
+        {
+            List<GuildSettingsDTO> guildSettings = await _dbApi.GetGuildSettings(true).ConfigureAwait(false);
+            foreach (GuildSettingsDTO dto in guildSettings)
+                _guildPrefixPairs.Add(dto.GuildId, dto.Prefix);
+
+            IsSetup = true;
+        }
+
+        public async Task UpdatePrefixAsync(ulong guildId, string newPrefix)
+        {
+            _guildPrefixPairs[guildId] = newPrefix;
+            await UpdateDbPrefix(guildId, newPrefix).ConfigureAwait(false);
+        }
+
+        private async Task UpdateDbPrefix(ulong guildId, string newPrefix)
+        {
+            GuildSettingsDTO settings = await _dbApi.GetGuildSetting(guildId).ConfigureAwait(false);
+            settings.Prefix = newPrefix;
+            await _dbApi.UpdateGuildSettings(guildId, settings).ConfigureAwait(false);
+        }
+    }
+}

--- a/UVOCBot/Services/PrefixService.cs
+++ b/UVOCBot/Services/PrefixService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Options;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UVOCBot.Config;
@@ -23,6 +24,9 @@ namespace UVOCBot.Services
 
         public string GetPrefix(ulong guildId)
         {
+            if (!IsSetup)
+                throw new InvalidOperationException("Please call SetupAsync() before using the " + nameof(PrefixService));
+
             if (_guildPrefixPairs.ContainsKey(guildId))
                 return _guildPrefixPairs[guildId];
             else
@@ -31,6 +35,9 @@ namespace UVOCBot.Services
 
         public async Task RemovePrefixAsync(ulong guildId)
         {
+            if (!IsSetup)
+                throw new InvalidOperationException("Please call SetupAsync() before using the " + nameof(PrefixService));
+
             _guildPrefixPairs.Remove(guildId);
             await UpdateDbPrefix(guildId, null).ConfigureAwait(false);
         }
@@ -46,13 +53,16 @@ namespace UVOCBot.Services
 
         public async Task UpdatePrefixAsync(ulong guildId, string newPrefix)
         {
+            if (!IsSetup)
+                throw new InvalidOperationException("Please call SetupAsync() before using the " + nameof(PrefixService));
+
             _guildPrefixPairs[guildId] = newPrefix;
             await UpdateDbPrefix(guildId, newPrefix).ConfigureAwait(false);
         }
 
         private async Task UpdateDbPrefix(ulong guildId, string newPrefix)
         {
-            GuildSettingsDTO settings = await _dbApi.GetGuildSetting(guildId).ConfigureAwait(false);
+            GuildSettingsDTO settings = await _dbApi.GetGuildSettingsAsync(guildId).ConfigureAwait(false);
             settings.Prefix = newPrefix;
             await _dbApi.UpdateGuildSettings(guildId, settings).ConfigureAwait(false);
         }

--- a/UVOCBot/Services/PrefixService.cs
+++ b/UVOCBot/Services/PrefixService.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Extensions.Options;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using UVOCBot.Config;
 using UVOCBot.Core.Model;
 
 namespace UVOCBot.Services
@@ -7,13 +9,15 @@ namespace UVOCBot.Services
     public class PrefixService : IPrefixService
     {
         private readonly IApiService _dbApi;
+        private readonly GeneralOptions _generalOptions;
         private readonly Dictionary<ulong, string> _guildPrefixPairs;
 
         public bool IsSetup { get; protected set; }
 
-        public PrefixService(IApiService dbApi)
+        public PrefixService(IApiService dbApi, IOptions<GeneralOptions> generalOptions)
         {
             _dbApi = dbApi;
+            _generalOptions = generalOptions.Value;
             _guildPrefixPairs = new Dictionary<ulong, string>();
         }
 
@@ -22,7 +26,7 @@ namespace UVOCBot.Services
             if (_guildPrefixPairs.ContainsKey(guildId))
                 return _guildPrefixPairs[guildId];
             else
-                return IPrefixService.DEFAULT_PREFIX;
+                return _generalOptions.CommandPrefix;
         }
 
         public async Task RemovePrefixAsync(ulong guildId)

--- a/UVOCBot/Workers/DiscordWorker.cs
+++ b/UVOCBot/Workers/DiscordWorker.cs
@@ -3,6 +3,7 @@ using DSharpPlus.Entities;
 using Microsoft.Extensions.Hosting;
 using System.Threading;
 using System.Threading.Tasks;
+using UVOCBot.Services;
 
 namespace UVOCBot.Workers
 {
@@ -20,7 +21,7 @@ namespace UVOCBot.Workers
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            await _discordClient.ConnectAsync(new DiscordActivity(Program.DEFAULT_PREFIX + "help", ActivityType.ListeningTo)).ConfigureAwait(false);
+            await _discordClient.ConnectAsync(new DiscordActivity(IPrefixService.DEFAULT_PREFIX + "help", ActivityType.ListeningTo)).ConfigureAwait(false);
             await Task.Delay(-1, stoppingToken).ConfigureAwait(false);
         }
 

--- a/UVOCBot/Workers/DiscordWorker.cs
+++ b/UVOCBot/Workers/DiscordWorker.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using System.Threading;
 using System.Threading.Tasks;
 using UVOCBot.Config;
+using UVOCBot.Services;
 
 namespace UVOCBot.Workers
 {
@@ -12,17 +13,21 @@ namespace UVOCBot.Workers
     {
         private readonly DiscordClient _discordClient;
         private readonly GeneralOptions _generalOptions;
+        private readonly IPrefixService _prefixService;
 
         public DiscordWorker(
             DiscordClient discordClient,
-            IOptions<GeneralOptions> generalOptions)
+            IOptions<GeneralOptions> generalOptions,
+            IPrefixService prefixService)
         {
             _discordClient = discordClient;
             _generalOptions = generalOptions.Value;
+            _prefixService = prefixService;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            await _prefixService.SetupAsync().ConfigureAwait(false);
             await _discordClient.ConnectAsync(new DiscordActivity(_generalOptions.CommandPrefix + "help", ActivityType.ListeningTo)).ConfigureAwait(false);
             await Task.Delay(-1, stoppingToken).ConfigureAwait(false);
         }

--- a/UVOCBot/Workers/DiscordWorker.cs
+++ b/UVOCBot/Workers/DiscordWorker.cs
@@ -12,11 +12,9 @@ namespace UVOCBot.Workers
         private readonly DiscordClient _discordClient;
 
         public DiscordWorker(
-            IHostApplicationLifetime appLifetime,
             DiscordClient discordClient)
         {
             _discordClient = discordClient;
-            appLifetime.ApplicationStopping.Register(OnStopping);
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -25,9 +23,9 @@ namespace UVOCBot.Workers
             await Task.Delay(-1, stoppingToken).ConfigureAwait(false);
         }
 
-        private void OnStopping()
+        public override async Task StopAsync(CancellationToken cancellationToken)
         {
-            _discordClient.DisconnectAsync().Wait();
+            await _discordClient.DisconnectAsync().ConfigureAwait(false);
         }
     }
 }

--- a/UVOCBot/Workers/DiscordWorker.cs
+++ b/UVOCBot/Workers/DiscordWorker.cs
@@ -1,25 +1,29 @@
 using DSharpPlus;
 using DSharpPlus.Entities;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using System.Threading;
 using System.Threading.Tasks;
-using UVOCBot.Services;
+using UVOCBot.Config;
 
 namespace UVOCBot.Workers
 {
     public sealed class DiscordWorker : BackgroundService
     {
         private readonly DiscordClient _discordClient;
+        private readonly GeneralOptions _generalOptions;
 
         public DiscordWorker(
-            DiscordClient discordClient)
+            DiscordClient discordClient,
+            IOptions<GeneralOptions> generalOptions)
         {
             _discordClient = discordClient;
+            _generalOptions = generalOptions.Value;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            await _discordClient.ConnectAsync(new DiscordActivity(IPrefixService.DEFAULT_PREFIX + "help", ActivityType.ListeningTo)).ConfigureAwait(false);
+            await _discordClient.ConnectAsync(new DiscordActivity(_generalOptions.CommandPrefix + "help", ActivityType.ListeningTo)).ConfigureAwait(false);
             await Task.Delay(-1, stoppingToken).ConfigureAwait(false);
         }
 

--- a/UVOCBot/Workers/TwitterWorker.cs
+++ b/UVOCBot/Workers/TwitterWorker.cs
@@ -169,7 +169,7 @@ namespace UVOCBot.Workers
                 case ChannelReturnedInfo.GetChannelStatus.GuildNotFound:
                     return; // TODO: Do something if the guild was not found
                 case ChannelReturnedInfo.GetChannelStatus.Fallback:
-                    await channelInfo.Channel.SendMessageAsync($"The tweet relay channel could not be found. Please reset it using the `{Program.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
+                    await channelInfo.Channel.SendMessageAsync($"The tweet relay channel could not be found. Please reset it using the `{IPrefixService.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
                     break;
             }
 

--- a/UVOCBot/Workers/TwitterWorker.cs
+++ b/UVOCBot/Workers/TwitterWorker.cs
@@ -1,5 +1,6 @@
 ﻿using DSharpPlus;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,7 @@ using System.Threading.Tasks;
 using Tweetinvi;
 using Tweetinvi.Models;
 using Tweetinvi.Parameters;
+using UVOCBot.Config;
 using UVOCBot.Core.Model;
 using UVOCBot.Model;
 using UVOCBot.Services;
@@ -21,6 +23,7 @@ namespace UVOCBot.Workers
         private readonly ITwitterClient _twitterClient;
         private readonly IApiService _dbApi;
         private readonly ISettingsService _settingsService;
+        private readonly GeneralOptions _generalOptions;
 
         private readonly MaxSizeQueue<long> _previousTweetIds = new MaxSizeQueue<long>(100);
 
@@ -28,12 +31,14 @@ namespace UVOCBot.Workers
             DiscordClient discordClient,
             ITwitterClient twitterClient,
             IApiService dbApi,
-            ISettingsService settingsService)
+            ISettingsService settingsService,
+            IOptions<GeneralOptions> generalOptions)
         {
             _discordClient = discordClient;
             _twitterClient = twitterClient;
             _dbApi = dbApi;
             _settingsService = settingsService;
+            _generalOptions = generalOptions.Value;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -169,7 +174,7 @@ namespace UVOCBot.Workers
                 case ChannelReturnedInfo.GetChannelStatus.GuildNotFound:
                     return; // TODO: Do something if the guild was not found
                 case ChannelReturnedInfo.GetChannelStatus.Fallback:
-                    await channelInfo.Channel.SendMessageAsync($"The tweet relay channel could not be found. Please reset it using the `{IPrefixService.DEFAULT_PREFIX}twitter relay-channel` command").ConfigureAwait(false);
+                    await channelInfo.Channel.SendMessageAsync($"The tweet relay channel could not be found. Please reset it using the `{_generalOptions.CommandPrefix}twitter relay-channel` command").ConfigureAwait(false);
                     break;
             }
 

--- a/UVOCBot/appsettings.json
+++ b/UVOCBot/appsettings.json
@@ -7,6 +7,7 @@
   "GeneralOptions": {
     "BotToken": "",
     "ApiEndpoint": "http://localhost:42718/api",
-    "CensusApiKey": ""
+    "CensusApiKey": "",
+    "CommandPrefix": "ub!"
   }
 }


### PR DESCRIPTION
This PR lets a guild set custom prefixes, using the command `prefix <string>`.

To allow this, a `Prefix` property was added to `GuildSettings`.
The default prefix is also now configurable via `appsettings.json`.