### PR TITLE
Allow a guild to set a default PlanetSide server

### DIFF
--- a/UVOCBot.Api/BotContext.cs
+++ b/UVOCBot.Api/BotContext.cs
@@ -12,6 +12,7 @@ namespace UVOCBot.Api
         public DbSet<GuildSettings> GuildSettings { get; set; }
         public DbSet<GuildTwitterSettings> GuildTwitterSettings { get; set; }
         public DbSet<TwitterUser> TwitterUsers { get; set; }
+        public DbSet<PlanetsideSettings> PlanetsideSettings { get; set; }
 
         public BotContext(IOptions<DatabaseOptions> config)
         {

--- a/UVOCBot.Api/Controllers/PlanetsideSettingsController.cs
+++ b/UVOCBot.Api/Controllers/PlanetsideSettingsController.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using UVOCBot.Api.Model;
+using UVOCBot.Core.Model;
+
+namespace UVOCBot.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PlanetsideSettingsController : ControllerBase
+    {
+        private readonly BotContext _context;
+
+        public PlanetsideSettingsController(BotContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/GuildSettings
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<PlanetsideSettingsDTO>>> GetPlanetsideSettings()
+        {
+            return (await _context.PlanetsideSettings.ToListAsync().ConfigureAwait(false)).ConvertAll(e => ToDTO(e));
+        }
+
+        // GET: api/PlanetsideSettings/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<PlanetsideSettingsDTO>> GetPlanetsideSettings(ulong id)
+        {
+            var planetsideSettings = await _context.PlanetsideSettings.FindAsync(id).ConfigureAwait(false);
+
+            return planetsideSettings == default ? NotFound() : ToDTO(planetsideSettings);
+        }
+
+        // PUT: api/PlanetsideSettings/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutPlanetsideSettings(ulong id, PlanetsideSettingsDTO planetsideSettings)
+        {
+            if (id != planetsideSettings.GuildId)
+                return BadRequest();
+
+            _context.Entry(FromDTO(planetsideSettings)).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync().ConfigureAwait(false);
+            }
+            catch (DbUpdateConcurrencyException) when (!PlanetsideSettingsExists(id))
+            {
+                return NotFound();
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/PlanetsideSettings
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<PlanetsideSettingsDTO>> PostPlanetsideSettings(PlanetsideSettingsDTO planetsideSettings)
+        {
+            _context.PlanetsideSettings.Add(FromDTO(planetsideSettings));
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+
+            return CreatedAtAction("GetPlanetsideSettings", new { id = planetsideSettings.GuildId }, planetsideSettings);
+        }
+
+        // DELETE: api/PlanetsideSettings/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeletePlanetsideSettings(ulong id)
+        {
+            var planetsideSettings = await _context.PlanetsideSettings.FindAsync(id).ConfigureAwait(false);
+            if (planetsideSettings == null)
+                return NotFound();
+
+            _context.PlanetsideSettings.Remove(planetsideSettings);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+
+            return NoContent();
+        }
+
+        private static PlanetsideSettingsDTO ToDTO(PlanetsideSettings settings)
+        {
+            return new PlanetsideSettingsDTO
+            {
+                GuildId = settings.GuildId,
+                DefaultWorld = settings.DefaultWorld
+            };
+        }
+
+        private static PlanetsideSettings FromDTO(PlanetsideSettingsDTO dto)
+        {
+            return new PlanetsideSettings
+            {
+                GuildId = dto.GuildId,
+                DefaultWorld = dto.DefaultWorld
+            };
+        }
+
+        private bool PlanetsideSettingsExists(ulong id)
+        {
+            return _context.PlanetsideSettings.Any(e => e.GuildId == id);
+        }
+    }
+}

--- a/UVOCBot.Api/Migrations/20210209042004_PlanetsideSettings.Designer.cs
+++ b/UVOCBot.Api/Migrations/20210209042004_PlanetsideSettings.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UVOCBot.Api;
 
-namespace UVOCBot.Migrations
+namespace UVOCBot.Api.Migrations
 {
     [DbContext(typeof(BotContext))]
-    partial class BotContextModelSnapshot : ModelSnapshot
+    [Migration("20210209042004_PlanetsideSettings")]
+    partial class PlanetsideSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/UVOCBot.Api/Migrations/20210209042004_PlanetsideSettings.cs
+++ b/UVOCBot.Api/Migrations/20210209042004_PlanetsideSettings.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace UVOCBot.Api.Migrations
+{
+    public partial class PlanetsideSettings : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlanetsideSettings",
+                columns: table => new
+                {
+                    GuildId = table.Column<ulong>(type: "bigint unsigned", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    DefaultWorld = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlanetsideSettings", x => x.GuildId);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlanetsideSettings");
+        }
+    }
+}

--- a/UVOCBot.Api/Model/GuildSettings.cs
+++ b/UVOCBot.Api/Model/GuildSettings.cs
@@ -8,18 +8,18 @@ namespace UVOCBot.Api.Model
     public sealed class GuildSettings
     {
         /// <summary>
-        /// Gets the Discord ID of this guild
+        /// Gets or sets the Discord ID of this guild
         /// </summary>
         [Key]
         public ulong GuildId { get; set; }
 
         /// <summary>
-        /// The channel to send users to when the bonk command is used
+        /// Gets or sets the channel to send users to when the bonk command is used
         /// </summary>
         public ulong? BonkChannelId { get; set; }
 
         /// <summary>
-        /// The prefix used to access bot commands
+        /// Gets or sets the prefix used to access bot commands
         /// </summary>
         public string Prefix { get; set; }
     }

--- a/UVOCBot.Api/Model/PlanetsideSettings.cs
+++ b/UVOCBot.Api/Model/PlanetsideSettings.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace UVOCBot.Api.Model
+{
+    public class PlanetsideSettings
+    {
+        /// <summary>
+        /// Gets the Discord ID of this guild
+        /// </summary>
+        [Key]
+        public ulong GuildId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default world to use
+        /// </summary>
+        public int? DefaultWorld { get; set; }
+    }
+}

--- a/UVOCBot.Core/Model/PlanetsideSettingsDTO.cs
+++ b/UVOCBot.Core/Model/PlanetsideSettingsDTO.cs
@@ -1,0 +1,29 @@
+﻿namespace UVOCBot.Core.Model
+{
+    public class PlanetsideSettingsDTO
+    {
+        /// <summary>
+        /// Gets the Discord ID of this guild
+        /// </summary>
+        public ulong GuildId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default world to use
+        /// </summary>
+        public int? DefaultWorld { get; set; }
+
+        public PlanetsideSettingsDTO()
+        {
+        }
+
+        public PlanetsideSettingsDTO(ulong guildId)
+        {
+            GuildId = guildId;
+        }
+
+        public override bool Equals(object obj) => obj is PlanetsideSettingsDTO s
+            && s.GuildId.Equals(GuildId);
+
+        public override int GetHashCode() => GuildId.GetHashCode();
+    }
+}

--- a/UVOCBot/Extensions/IApiServiceExtensions.cs
+++ b/UVOCBot/Extensions/IApiServiceExtensions.cs
@@ -10,7 +10,7 @@ namespace UVOCBot.Services
             GuildTwitterSettingsDTO settings;
             try
             {
-                settings = await service.GetGuildTwitterSetting(id).ConfigureAwait(false);
+                settings = await service.GetGuildTwitterSettings(id).ConfigureAwait(false);
             }
             catch
             {
@@ -42,12 +42,28 @@ namespace UVOCBot.Services
             GuildSettingsDTO settings;
             try
             {
-                settings = await service.GetGuildSetting(id).ConfigureAwait(false);
+                settings = await service.GetGuildSettings(id).ConfigureAwait(false);
             }
             catch
             {
                 settings = new GuildSettingsDTO(id);
                 await service.CreateGuildSettings(settings).ConfigureAwait(false);
+            }
+
+            return settings;
+        }
+
+        public static async Task<PlanetsideSettingsDTO> GetPlanetsideSettingsAsync(this IApiService service, ulong id)
+        {
+            PlanetsideSettingsDTO settings;
+            try
+            {
+                settings = await service.GetPlanetsideSettings(id).ConfigureAwait(false);
+            }
+            catch
+            {
+                settings = new PlanetsideSettingsDTO(id);
+                await service.CreatePlanetsideSettings(settings).ConfigureAwait(false);
             }
 
             return settings;

--- a/UVOCBot/Model/Planetside/LocalisedString.cs
+++ b/UVOCBot/Model/Planetside/LocalisedString.cs
@@ -4,7 +4,7 @@ namespace UVOCBot.Model.Planetside
 {
     public class LocalisedString
     {
-            [JsonProperty("en")]
-            public string English { get; set; }
+        [JsonProperty("en")]
+        public string English { get; set; }
     }
 }

--- a/UVOCBot/Services/IApiService.cs
+++ b/UVOCBot/Services/IApiService.cs
@@ -32,10 +32,10 @@ namespace UVOCBot.Services
         #region GuildTwitterSettings
 
         [Get("/guildtwittersettings")]
-        Task<List<GuildTwitterSettingsDTO>> GetGuildTwitterSettings([Query] bool filterByEnabled);
+        Task<List<GuildTwitterSettingsDTO>> GetAllGuildTwitterSettings([Query] bool filterByEnabled);
 
         [Get("/guildtwittersettings/{id}")]
-        Task<GuildTwitterSettingsDTO> GetGuildTwitterSetting(ulong id);
+        Task<GuildTwitterSettingsDTO> GetGuildTwitterSettings(ulong id);
 
         [Get("/guildtwittersettings/exists/{id}")]
         Task<bool> GuildTwitterSettingsExists(ulong id);
@@ -64,10 +64,10 @@ namespace UVOCBot.Services
         #region GuildSettings
 
         [Get("/guildsettings")]
-        Task<List<GuildSettingsDTO>> GetGuildSettings([Query] bool hasPrefix = false);
+        Task<List<GuildSettingsDTO>> GetAllGuildSettings([Query] bool hasPrefix = false);
 
         [Get("/guildsettings/{id}")]
-        Task<GuildSettingsDTO> GetGuildSetting(ulong id);
+        Task<GuildSettingsDTO> GetGuildSettings(ulong id);
 
         [Put("/guildsettings/{id}")]
         Task UpdateGuildSettings(ulong id, GuildSettingsDTO settings);
@@ -77,6 +77,25 @@ namespace UVOCBot.Services
 
         [Delete("/guildsettings/{id}")]
         Task DeleteGuildSettings(ulong id);
+
+        #endregion
+
+        #region PlanetsideSettings
+
+        [Get("/planetsidesettings")]
+        Task<List<PlanetsideSettingsDTO>> GetAllPlanetsideSettings();
+
+        [Get("/planetsidesettings/{id}")]
+        Task<PlanetsideSettingsDTO> GetPlanetsideSettings(ulong id);
+
+        [Put("/planetsidesettings/{id}")]
+        Task UpdatePlanetsideSettings(ulong id, PlanetsideSettingsDTO settings);
+
+        [Post("/planetsidesettings")]
+        Task<PlanetsideSettingsDTO> CreatePlanetsideSettings(PlanetsideSettingsDTO settings);
+
+        [Delete("/planetsidesettings/{id}")]
+        Task DeletePlanetsideSettings(ulong id);
 
         #endregion
     }

--- a/UVOCBot/Services/PrefixService.cs
+++ b/UVOCBot/Services/PrefixService.cs
@@ -44,7 +44,7 @@ namespace UVOCBot.Services
 
         public async Task SetupAsync()
         {
-            List<GuildSettingsDTO> guildSettings = await _dbApi.GetGuildSettings(true).ConfigureAwait(false);
+            List<GuildSettingsDTO> guildSettings = await _dbApi.GetAllGuildSettings(true).ConfigureAwait(false);
             foreach (GuildSettingsDTO dto in guildSettings)
                 _guildPrefixPairs.Add(dto.GuildId, dto.Prefix);
 

--- a/UVOCBot/Workers/TwitterWorker.cs
+++ b/UVOCBot/Workers/TwitterWorker.cs
@@ -56,7 +56,7 @@ namespace UVOCBot.Workers
                 int failureCount = 0;
 
                 // Load all of the twitter users we should relay tweets from
-                foreach (GuildTwitterSettingsDTO settings in await _dbApi.GetGuildTwitterSettings(true).ConfigureAwait(false))
+                foreach (GuildTwitterSettingsDTO settings in await _dbApi.GetAllGuildTwitterSettings(true).ConfigureAwait(false))
                 {
                     foreach (long twitterUserId in settings.TwitterUsers)
                     {


### PR DESCRIPTION
This PR lets a guild set a default PlanetSide server for use in the `population`, and any upcoming commands. This is done using the `default-server` command.

This required the addition of a `DefaultWorld` property in the database models. With an expectation for more planetside-related functions to be implemented, I have decided to create a new `PlanetsideSettings` POCO and the corresponding API controllers.