### PR TITLE
Implement Member Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Release X - XXX
+
+- Implemented a member grouping system for guilds. The following commands are utilised:
+    - `create`: Creates a new group from the given members
+    - `delete`: Deletes a group
+    - `info`: Gets information about a group
+    - `list`: Gets all of the groups created in this guild
+
+Technical Notes:
+- Added a `CleanupWorker` to the API project. Currently, this removes expired member groups every 15m, but it could be expanded to perform significantly more work that would be more efficient to perform locally, rather than transferring data to the client.
+
 ## Release v0.1.0 - 12/02/2021
 
 This is the first generally available release, as I am finally happy with the architecture and design patterns being utilised.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Before continuing, you should note that UVOCBot is designed with a linux system 
 
 UVOCBot has two main components:
 - The bot itself, `UVOCBot`. This is a .NET 5 Worker project, based on the `Microsoft.Extensions.Hosting` framework.
-- A RESTful API that abstracts the MariaDB database, `UVOCBot.Api`. This is built using `ASP.NET Core` and `Entity Framework Core`. This is simply a data abstraction layer; no data manipulation should occur here.
+- A RESTful API that abstracts the MariaDB database, `UVOCBot.Api`. This is built using `ASP.NET Core` and `Entity Framework Core`. This is by and large a data abstraction layer; very little data manipulation occurs here, except for where it would be inefficient for the client to perform non-user dependent actions.
 
 There is also a shared project, `UVOCBot.Core`, which contains models common to both projects.
 

--- a/UVOCBot.Api/BotContext.cs
+++ b/UVOCBot.Api/BotContext.cs
@@ -13,6 +13,7 @@ namespace UVOCBot.Api
         public DbSet<GuildTwitterSettings> GuildTwitterSettings { get; set; }
         public DbSet<TwitterUser> TwitterUsers { get; set; }
         public DbSet<PlanetsideSettings> PlanetsideSettings { get; set; }
+        public DbSet<MemberGroup> MemberGroups { get; set; }
 
         public BotContext(IOptions<DatabaseOptions> config)
         {

--- a/UVOCBot.Api/Controllers/GuildSettingsController.cs
+++ b/UVOCBot.Api/Controllers/GuildSettingsController.cs
@@ -68,7 +68,7 @@ namespace UVOCBot.Api.Controllers
             _context.GuildSettings.Add(FromDTO(guildSettings));
             await _context.SaveChangesAsync().ConfigureAwait(false);
 
-            return CreatedAtAction("GetGuildSettings", new { id = guildSettings.GuildId }, guildSettings);
+            return CreatedAtAction(nameof(GetGuildSettings), new { id = guildSettings.GuildId }, guildSettings);
         }
 
         // DELETE: api/GuildSettings/5

--- a/UVOCBot.Api/Controllers/GuildTwitterSettingsController.cs
+++ b/UVOCBot.Api/Controllers/GuildTwitterSettingsController.cs
@@ -41,7 +41,7 @@ namespace UVOCBot.Api.Controllers
         [HttpGet("exists/{id}")]
         public async Task<ActionResult<bool>> Exists(ulong id)
         {
-            return await _context.GuildTwitterSettings.FindAsync(id).ConfigureAwait(false) != null;
+            return await _context.GuildTwitterSettings.AnyAsync(s => s.GuildId == id).ConfigureAwait(false);
         }
 
         // PUT: api/GuildTwitterSettings/5

--- a/UVOCBot.Api/Controllers/MemberGroupController.cs
+++ b/UVOCBot.Api/Controllers/MemberGroupController.cs
@@ -25,14 +25,18 @@ namespace UVOCBot.Api.Controllers
         [HttpGet("{id}")]
         public async Task<ActionResult<MemberGroupDTO>> Get(ulong id)
         {
-            return ToDTO(await _context.MemberGroups.FindAsync(id).ConfigureAwait(false));
+            MemberGroup group = await _context.MemberGroups.FindAsync(id).ConfigureAwait(false);
+
+            return group == null ? NotFound() : ToDTO(group);
         }
 
         // GET api/MemberGroup/?guildId=1&groupName=""
         [HttpGet]
-        public ActionResult<MemberGroupDTO> Get([FromQuery] ulong guildId, [FromQuery] string groupName)
+        public async Task<ActionResult<MemberGroupDTO>> Get([FromQuery] ulong guildId, [FromQuery] string groupName)
         {
-            return ToDTO(_context.MemberGroups.First(g => g.GuildId == guildId && g.GroupName == groupName));
+            MemberGroup group = await _context.MemberGroups.FirstOrDefaultAsync(g => g.GuildId == guildId && g.GroupName == groupName).ConfigureAwait(false);
+
+            return group == default ? NotFound() : ToDTO(group);
         }
 
         // POST api/MemberGroup
@@ -74,11 +78,11 @@ namespace UVOCBot.Api.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(ulong id)
         {
-            MemberGroup memberGroup = await _context.MemberGroups.FindAsync(id).ConfigureAwait(false);
-            if (memberGroup == null)
+            MemberGroup group = await _context.MemberGroups.FindAsync(id).ConfigureAwait(false);
+            if (group is null)
                 return NotFound();
 
-            _context.MemberGroups.Remove(memberGroup);
+            _context.MemberGroups.Remove(group);
             await _context.SaveChangesAsync().ConfigureAwait(false);
 
             return NoContent();
@@ -98,7 +102,7 @@ namespace UVOCBot.Api.Controllers
             return NoContent();
         }
 
-        public MemberGroupDTO ToDTO(MemberGroup group)
+        private static MemberGroupDTO ToDTO(MemberGroup group)
         {
             return new MemberGroupDTO
             {
@@ -110,7 +114,7 @@ namespace UVOCBot.Api.Controllers
             };
         }
 
-        public MemberGroup FromDTO(MemberGroupDTO dto)
+        private static MemberGroup FromDTO(MemberGroupDTO dto)
         {
             return new MemberGroup
             {

--- a/UVOCBot.Api/Controllers/MemberGroupController.cs
+++ b/UVOCBot.Api/Controllers/MemberGroupController.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using UVOCBot.Api.Model;
+using UVOCBot.Core.Model;
+
+// For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace UVOCBot.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class MemberGroupController : ControllerBase
+    {
+        private readonly BotContext _context;
+
+        public MemberGroupController(BotContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/MemberGroup/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<MemberGroupDTO>> Get(ulong id)
+        {
+            return ToDTO(await _context.MemberGroups.FindAsync(id).ConfigureAwait(false));
+        }
+
+        // GET api/MemberGroup/?guildId=1&groupName=""
+        [HttpGet]
+        public ActionResult<MemberGroupDTO> Get([FromQuery] ulong guildId, [FromQuery] string groupName)
+        {
+            return ToDTO(_context.MemberGroups.First(g => g.GuildId == guildId && g.GroupName == groupName));
+        }
+
+        // POST api/MemberGroup
+        [HttpPost]
+        public async Task<ActionResult<MemberGroupDTO>> Post(MemberGroupDTO memberGroup)
+        {
+            IQueryable<MemberGroup> guildGroups = _context.MemberGroups.Where(g => g.GuildId.Equals(memberGroup.GuildId));
+            if (guildGroups.Any(g => g.GroupName.Equals(memberGroup.GroupName)))
+                return Conflict();
+
+            _context.MemberGroups.Add(FromDTO(memberGroup));
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+
+            return CreatedAtAction("GetMemberGroup", new { id = memberGroup.Id }, memberGroup);
+        }
+
+        // PUT api/MemberGroup/5
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Put(ulong id, MemberGroupDTO memberGroup)
+        {
+            if (id != memberGroup.Id)
+                return BadRequest();
+
+            _context.Entry(FromDTO(memberGroup)).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync().ConfigureAwait(false);
+            }
+            catch (DbUpdateConcurrencyException) when (!MemberGroupExists(id))
+            {
+                return NotFound();
+            }
+
+            return NoContent();
+        }
+
+        // DELETE api/MemberGroup/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(ulong id)
+        {
+            MemberGroup memberGroup = await _context.MemberGroups.FindAsync(id).ConfigureAwait(false);
+            if (memberGroup == null)
+                return NotFound();
+
+            _context.MemberGroups.Remove(memberGroup);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+
+            return NoContent();
+        }
+
+        // DELETE api/MemberGroup/?guildId=1&groupName=""
+        [HttpDelete]
+        public async Task<IActionResult> Delete([FromQuery] ulong guildId, [FromQuery] string groupName)
+        {
+            MemberGroup group = _context.MemberGroups.First(g => g.GuildId == guildId && g.GroupName == groupName);
+            if (group is null)
+                return NotFound();
+
+            _context.MemberGroups.Remove(group);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+
+            return NoContent();
+        }
+
+        public MemberGroupDTO ToDTO(MemberGroup group)
+        {
+            return new MemberGroupDTO
+            {
+                Id = group.Id,
+                GuildId = group.GuildId,
+                CreatedAt = group.CreatedAt,
+                GroupName = group.GroupName,
+                UserIds = new List<ulong>(group.UserIds.Split('\n').Select(s => ulong.Parse(s)))
+            };
+        }
+
+        public MemberGroup FromDTO(MemberGroupDTO dto)
+        {
+            return new MemberGroup
+            {
+                Id = dto.Id,
+                GuildId = dto.GuildId,
+                CreatedAt = dto.CreatedAt,
+                GroupName = dto.GroupName,
+                UserIds = string.Join('\n', dto.UserIds.Select(i => i.ToString()))
+            };
+        }
+
+        private bool MemberGroupExists(ulong id)
+        {
+            return _context.MemberGroups.Any(e => e.Id == id);
+        }
+    }
+}

--- a/UVOCBot.Api/Controllers/PlanetsideSettingsController.cs
+++ b/UVOCBot.Api/Controllers/PlanetsideSettingsController.cs
@@ -32,7 +32,7 @@ namespace UVOCBot.Api.Controllers
         {
             var planetsideSettings = await _context.PlanetsideSettings.FindAsync(id).ConfigureAwait(false);
 
-            return planetsideSettings == default ? NotFound() : ToDTO(planetsideSettings);
+            return planetsideSettings == null ? NotFound() : ToDTO(planetsideSettings);
         }
 
         // PUT: api/PlanetsideSettings/5

--- a/UVOCBot.Api/Controllers/PlanetsideSettingsController.cs
+++ b/UVOCBot.Api/Controllers/PlanetsideSettingsController.cs
@@ -65,7 +65,7 @@ namespace UVOCBot.Api.Controllers
             _context.PlanetsideSettings.Add(FromDTO(planetsideSettings));
             await _context.SaveChangesAsync().ConfigureAwait(false);
 
-            return CreatedAtAction("GetPlanetsideSettings", new { id = planetsideSettings.GuildId }, planetsideSettings);
+            return CreatedAtAction(nameof(GetPlanetsideSettings), new { id = planetsideSettings.GuildId }, planetsideSettings);
         }
 
         // DELETE: api/PlanetsideSettings/5

--- a/UVOCBot.Api/Controllers/TwitterUserController.cs
+++ b/UVOCBot.Api/Controllers/TwitterUserController.cs
@@ -32,13 +32,13 @@ namespace UVOCBot.Api.Controllers
         {
             var twitterUser = await _context.TwitterUsers.FindAsync(id).ConfigureAwait(false);
 
-            return twitterUser == default ? NotFound() : ToDTO(twitterUser);
+            return twitterUser == null ? NotFound() : ToDTO(twitterUser);
         }
 
         [HttpGet("exists/{id}")]
         public async Task<ActionResult<bool>> Exists(long id)
         {
-            return await _context.TwitterUsers.FindAsync(id).ConfigureAwait(false) != null;
+            return await _context.TwitterUsers.AnyAsync(u => u.UserId == id).ConfigureAwait(false);
         }
 
         // PUT: api/TwitterUser/5

--- a/UVOCBot.Api/Migrations/20210228005425_MemberGroups.Designer.cs
+++ b/UVOCBot.Api/Migrations/20210228005425_MemberGroups.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UVOCBot.Api;
 
-namespace UVOCBot.Migrations
+namespace UVOCBot.Api.Migrations
 {
     [DbContext(typeof(BotContext))]
-    partial class BotContextModelSnapshot : ModelSnapshot
+    [Migration("20210228005425_MemberGroups")]
+    partial class MemberGroups
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/UVOCBot.Api/Migrations/20210228005425_MemberGroups.cs
+++ b/UVOCBot.Api/Migrations/20210228005425_MemberGroups.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace UVOCBot.Api.Migrations
+{
+    public partial class MemberGroups : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MemberGroups",
+                columns: table => new
+                {
+                    Id = table.Column<ulong>(type: "bigint unsigned", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    GuildId = table.Column<ulong>(type: "bigint unsigned", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetime(6)", nullable: false),
+                    GroupName = table.Column<string>(type: "varchar(255)", nullable: true),
+                    UserIds = table.Column<string>(type: "longtext", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MemberGroups", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MemberGroups_GroupName",
+                table: "MemberGroups",
+                column: "GroupName");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MemberGroups");
+        }
+    }
+}

--- a/UVOCBot.Api/Migrations/20210312223201_UpdateMemberGroup.Designer.cs
+++ b/UVOCBot.Api/Migrations/20210312223201_UpdateMemberGroup.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UVOCBot.Api;
 
-namespace UVOCBot.Migrations
+namespace UVOCBot.Api.Migrations
 {
     [DbContext(typeof(BotContext))]
-    partial class BotContextModelSnapshot : ModelSnapshot
+    [Migration("20210312223201_UpdateMemberGroup")]
+    partial class UpdateMemberGroup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/UVOCBot.Api/Migrations/20210312223201_UpdateMemberGroup.cs
+++ b/UVOCBot.Api/Migrations/20210312223201_UpdateMemberGroup.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace UVOCBot.Api.Migrations
+{
+    public partial class UpdateMemberGroup : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<ulong>(
+                name: "CreatorId",
+                table: "MemberGroups",
+                type: "bigint unsigned",
+                nullable: false,
+                defaultValue: 0ul);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatorId",
+                table: "MemberGroups");
+        }
+    }
+}

--- a/UVOCBot.Api/Model/MemberGroup.cs
+++ b/UVOCBot.Api/Model/MemberGroup.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace UVOCBot.Api.Model
+{
+    [Index(nameof(GroupName), IsUnique = false)]
+    public class MemberGroup
+    {
+        public const int MAX_LIFETIME_HOURS = 24;
+
+        [Key]
+        public ulong Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets ID of the guild that this group belongs to
+        /// </summary>
+        public ulong GuildId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time that this group was created at
+        /// </summary>
+        public DateTimeOffset CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the group
+        /// </summary>
+        public string GroupName { get; set; }
+
+        /// <summary>
+        /// An LF delimited list of the users in this group
+        /// </summary>
+        public string UserIds { get; set; }
+    }
+}

--- a/UVOCBot.Api/Model/MemberGroup.cs
+++ b/UVOCBot.Api/Model/MemberGroup.cs
@@ -18,6 +18,11 @@ namespace UVOCBot.Api.Model
         public ulong GuildId { get; set; }
 
         /// <summary>
+        /// The ID of the Discord user that created this group
+        /// </summary>
+        public ulong CreatorId { get; set; }
+
+        /// <summary>
         /// Gets or sets the time that this group was created at
         /// </summary>
         public DateTimeOffset CreatedAt { get; set; }

--- a/UVOCBot.Api/Startup.cs
+++ b/UVOCBot.Api/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using UVOCBot.Api.Workers;
 
 namespace UVOCBot.Api
 {
@@ -23,6 +24,7 @@ namespace UVOCBot.Api
             services.AddDbContext<BotContext>();
             services.AddControllers();
             services.AddSwaggerGen(c => c.SwaggerDoc("v1", new OpenApiInfo { Title = "UVOCBot.Api", Version = "v1" }));
+            services.AddHostedService<CleanupWorker>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/UVOCBot.Api/Workers/CleanupWorker.cs
+++ b/UVOCBot.Api/Workers/CleanupWorker.cs
@@ -26,11 +26,11 @@ namespace UVOCBot.Api.Workers
 
                     foreach (MemberGroup group in db.MemberGroups)
                     {
-                        if (group.CreatedAt.AddHours(MemberGroup.MAX_LIFETIME_HOURS) > DateTimeOffset.Now)
+                        if (group.CreatedAt.AddHours(MemberGroup.MAX_LIFETIME_HOURS) > DateTimeOffset.UtcNow)
                             db.MemberGroups.Remove(group);
                     }
 
-                    await db.SaveChangesAsync().ConfigureAwait(false);
+                    await db.SaveChangesAsync(stoppingToken).ConfigureAwait(false);
                 }
 
                 await Task.Delay(900000, stoppingToken).ConfigureAwait(false); // Work every 15min

--- a/UVOCBot.Api/Workers/CleanupWorker.cs
+++ b/UVOCBot.Api/Workers/CleanupWorker.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UVOCBot.Api.Model;
+
+namespace UVOCBot.Api.Workers
+{
+    public class CleanupWorker : BackgroundService
+    {
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+
+        public CleanupWorker(IServiceScopeFactory serviceScopeFactory)
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+        }
+
+        protected async override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (true)
+            {
+                using (IServiceScope scope = _serviceScopeFactory.CreateScope())
+                {
+                    BotContext db = scope.ServiceProvider.GetRequiredService<BotContext>();
+
+                    foreach (MemberGroup group in db.MemberGroups)
+                    {
+                        if (group.CreatedAt.AddHours(MemberGroup.MAX_LIFETIME_HOURS) > DateTimeOffset.Now)
+                            db.MemberGroups.Remove(group);
+                    }
+
+                    await db.SaveChangesAsync().ConfigureAwait(false);
+                }
+
+                await Task.Delay(900000, stoppingToken).ConfigureAwait(false); // Work every 15min
+            }
+        }
+    }
+}

--- a/UVOCBot.Api/Workers/CleanupWorker.cs
+++ b/UVOCBot.Api/Workers/CleanupWorker.cs
@@ -26,7 +26,7 @@ namespace UVOCBot.Api.Workers
 
                     foreach (MemberGroup group in db.MemberGroups)
                     {
-                        if (group.CreatedAt.AddHours(MemberGroup.MAX_LIFETIME_HOURS) > DateTimeOffset.UtcNow)
+                        if (group.CreatedAt.AddHours(MemberGroup.MAX_LIFETIME_HOURS) < DateTimeOffset.UtcNow)
                             db.MemberGroups.Remove(group);
                     }
 

--- a/UVOCBot.Core/Model/MemberGroupDTO.cs
+++ b/UVOCBot.Core/Model/MemberGroupDTO.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UVOCBot.Core.Model
+{
+    public class MemberGroupDTO
+    {
+        public const int MAX_LIFETIME_HOURS = 24;
+
+        public ulong Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets ID of the guild that this group belongs to
+        /// </summary>
+        public ulong GuildId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time that this group was created at
+        /// </summary>
+        public DateTimeOffset CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the group
+        /// </summary>
+        public string GroupName { get; set; }
+
+        public List<ulong> UserIds { get; set; }
+    }
+}

--- a/UVOCBot.Core/Model/MemberGroupDTO.cs
+++ b/UVOCBot.Core/Model/MemberGroupDTO.cs
@@ -15,6 +15,11 @@ namespace UVOCBot.Core.Model
         public ulong GuildId { get; set; }
 
         /// <summary>
+        /// The ID of the Discord user that created this group
+        /// </summary>
+        public ulong CreatorId { get; set; }
+
+        /// <summary>
         /// Gets or sets the UTC time that this group was created at
         /// </summary>
         public DateTimeOffset CreatedAt { get; set; }
@@ -28,10 +33,11 @@ namespace UVOCBot.Core.Model
 
         public MemberGroupDTO() { }
 
-        public MemberGroupDTO(string groupName, ulong guildId, List<ulong> userIds)
+        public MemberGroupDTO(string groupName, ulong guildId, ulong creatorId, List<ulong> userIds)
         {
             GroupName = groupName;
             GuildId = guildId;
+            CreatorId = creatorId;
             UserIds = userIds;
             CreatedAt = DateTimeOffset.UtcNow;
         }

--- a/UVOCBot.Core/Model/MemberGroupDTO.cs
+++ b/UVOCBot.Core/Model/MemberGroupDTO.cs
@@ -15,7 +15,7 @@ namespace UVOCBot.Core.Model
         public ulong GuildId { get; set; }
 
         /// <summary>
-        /// Gets or sets the time that this group was created at
+        /// Gets or sets the UTC time that this group was created at
         /// </summary>
         public DateTimeOffset CreatedAt { get; set; }
 
@@ -25,5 +25,15 @@ namespace UVOCBot.Core.Model
         public string GroupName { get; set; }
 
         public List<ulong> UserIds { get; set; }
+
+        public MemberGroupDTO() { }
+
+        public MemberGroupDTO(string groupName, ulong guildId, List<ulong> userIds)
+        {
+            GroupName = groupName;
+            GuildId = guildId;
+            UserIds = userIds;
+            CreatedAt = DateTimeOffset.UtcNow;
+        }
     }
 }

--- a/UVOCBot/Commands/MemberGroupsModule.cs
+++ b/UVOCBot/Commands/MemberGroupsModule.cs
@@ -2,6 +2,7 @@
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -34,9 +35,11 @@ namespace UVOCBot.Commands
 
                 MemberReturnedInfo groupCreator = await ctx.Guild.TryGetMemberAsync(g.CreatorId).ConfigureAwait(false);
                 if (groupCreator.Status == MemberReturnedInfo.GetMemberStatus.Failure)
-                    sb.AppendLine("`unknown member`");
+                    sb.Append("`unknown member`");
                 else
-                    sb.AppendLine(groupCreator.Member.Mention);
+                    sb.Append(groupCreator.Member.Mention);
+
+                sb.Append(", expiring in ").AppendLine((g.CreatedAt.AddHours(MemberGroupDTO.MAX_LIFETIME_HOURS) - DateTimeOffset.UtcNow).ToString(@"hh\h\ mm\m"));
             }
 
             DiscordMessageBuilder builder = new();

--- a/UVOCBot/Commands/MemberGroupsModule.cs
+++ b/UVOCBot/Commands/MemberGroupsModule.cs
@@ -1,7 +1,14 @@
-﻿using DSharpPlus.CommandsNext;
+﻿using DSharpPlus;
+using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using UVOCBot.Core.Model;
+using UVOCBot.Extensions;
+using UVOCBot.Services;
 
 namespace UVOCBot.Commands
 {
@@ -10,11 +17,68 @@ namespace UVOCBot.Commands
     [Group("group")]
     public class MemberGroupsModule : BaseCommandModule
     {
+        public IApiService DbApi { get; set; }
+
+        [Command("list")]
+        [Description("Gets all of the groups created in this guild")]
+        public async Task GetGroupsCommand(CommandContext ctx)
+        {
+            List<MemberGroupDTO> groups = await DbApi.GetAllGuildMemberGroups(ctx.Guild.Id).ConfigureAwait(false);
+
+            StringBuilder sb = new();
+            sb.Append("Showing ").Append(Formatter.InlineCode(groups.Count.ToString())).Append(" groups for ").AppendLine(Formatter.InlineCode(ctx.Guild.Name)).AppendLine();
+
+            foreach (MemberGroupDTO g in groups)
+            {
+                sb.Append("• ").Append(Formatter.InlineCode(g.GroupName)).Append(" (").Append(g.UserIds.Count).Append(" members) - created by ");
+
+                MemberReturnedInfo groupCreator = await ctx.Guild.TryGetMemberAsync(g.CreatorId).ConfigureAwait(false);
+                if (groupCreator.Status == MemberReturnedInfo.GetMemberStatus.Failure)
+                    sb.AppendLine("`unknown member`");
+                else
+                    sb.AppendLine(groupCreator.Member.Mention);
+            }
+
+            await ctx.RespondAsync(sb.ToString()).ConfigureAwait(false);
+        }
+
         [Command("create")]
         [Description("Creates a new group from the given members")]
         public async Task CreateGroupCommand(
+            CommandContext ctx,
             [Description("The unique name of the group")] string groupName,
             [Description("The members to include in the group")] params DiscordMember[] members)
+        {
+            if (string.IsNullOrEmpty(groupName) || groupName.Length < 3)
+            {
+                await ctx.RespondWithErrorAsync("The group name must be at least three characters in length.").ConfigureAwait(false);
+                return;
+            }
+
+            if (members.Length < 2 || members.Length > 50)
+            {
+                await ctx.RespondWithErrorAsync("A group must contain between two and 50 members.").ConfigureAwait(false);
+                return;
+            }
+
+            MemberGroupDTO group = new(groupName, ctx.Guild.Id, ctx.User.Id, members.Select(m => m.Id).ToList());
+
+            try
+            {
+                await DbApi.CreateMemberGroup(group).ConfigureAwait(false);
+                await ctx.RespondWithSuccessAsync($"The group {Formatter.Bold(groupName)} has been created with {Formatter.Bold(members.Length.ToString())} members.").ConfigureAwait(false);
+            }
+            catch (Refit.ApiException apiEx) when (apiEx.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                await ctx.RespondWithErrorAsync("A group with this name already exists. Please try again with a different name.").ConfigureAwait(false);
+            }
+        }
+
+        [Command("delete")]
+        [Description("Deletes a group")]
+        public async Task DeleteGroupCommand(
+            CommandContext ctx,
+            [Description("The unique name of the guild")] string groupName)
         {
 
         }

--- a/UVOCBot/Commands/MemberGroupsModule.cs
+++ b/UVOCBot/Commands/MemberGroupsModule.cs
@@ -1,0 +1,30 @@
+﻿using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+using System.Threading.Tasks;
+
+namespace UVOCBot.Commands
+{
+    [Description("Commands that allow groups of members to be created")]
+    [RequireGuild]
+    [Group("group")]
+    public class MemberGroupsModule : BaseCommandModule
+    {
+        [Command("create")]
+        [Description("Creates a new group from the given members")]
+        public async Task CreateGroupCommand(
+            [Description("The unique name of the group")] string groupName,
+            [Description("The members to include in the group")] params DiscordMember[] members)
+        {
+
+        }
+
+        [Command("create")]
+        [Description("Creates a new group from the given role")]
+        public async Task CreateGroupCommand(
+            [Description("The unique name of the group")] string groupName,
+            [Description("Members with this role will be included in the group")] DiscordRole role)
+        {
+        }
+    }
+}

--- a/UVOCBot/Commands/MemberGroupsModule.cs
+++ b/UVOCBot/Commands/MemberGroupsModule.cs
@@ -18,13 +18,5 @@ namespace UVOCBot.Commands
         {
 
         }
-
-        [Command("create")]
-        [Description("Creates a new group from the given role")]
-        public async Task CreateGroupCommand(
-            [Description("The unique name of the group")] string groupName,
-            [Description("Members with this role will be included in the group")] DiscordRole role)
-        {
-        }
     }
 }

--- a/UVOCBot/Commands/MemberGroupsModule.cs
+++ b/UVOCBot/Commands/MemberGroupsModule.cs
@@ -2,7 +2,6 @@
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
-using Refit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -81,7 +80,7 @@ namespace UVOCBot.Commands
 
                 await ctx.RespondAsync(builder).ConfigureAwait(false);
             }
-            catch (ValidationApiException va) when (va.StatusCode == System.Net.HttpStatusCode.NotFound)
+            catch (Refit.ValidationApiException va) when (va.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 await ctx.RespondWithErrorAsync("That group does not exist.").ConfigureAwait(false);
                 return;
@@ -110,9 +109,17 @@ namespace UVOCBot.Commands
                 return;
             }
 
-            if (members.Length < 2 || members.Length > 50)
+            if (members.Length > 50)
             {
-                await ctx.RespondWithErrorAsync("A group must contain between two and 50 members.").ConfigureAwait(false);
+                await ctx.RespondWithErrorAsync("A group cannot have more than 50 members.").ConfigureAwait(false);
+                return;
+            }
+
+            members = members.Distinct().ToArray();
+
+            if (members.Length < 2)
+            {
+                await ctx.RespondWithErrorAsync("A group cannot have less than two members, excluding duplicates.").ConfigureAwait(false);
                 return;
             }
 

--- a/UVOCBot/Commands/MemberGroupsModule.cs
+++ b/UVOCBot/Commands/MemberGroupsModule.cs
@@ -21,7 +21,7 @@ namespace UVOCBot.Commands
 
         [Command("list")]
         [Description("Gets all of the groups created in this guild")]
-        public async Task GetGroupsCommand(CommandContext ctx)
+        public async Task ListGroupsCommand(CommandContext ctx)
         {
             List<MemberGroupDTO> groups = await DbApi.GetAllGuildMemberGroups(ctx.Guild.Id).ConfigureAwait(false);
 
@@ -39,7 +39,11 @@ namespace UVOCBot.Commands
                     sb.AppendLine(groupCreator.Member.Mention);
             }
 
-            await ctx.RespondAsync(sb.ToString()).ConfigureAwait(false);
+            DiscordMessageBuilder builder = new();
+            builder.WithContent(sb.ToString());
+            builder.WithAllowedMentions(Mentions.None);
+
+            await ctx.RespondAsync(builder).ConfigureAwait(false);
         }
 
         [Command("create")]

--- a/UVOCBot/Commands/TeamGenerationModule.cs
+++ b/UVOCBot/Commands/TeamGenerationModule.cs
@@ -14,7 +14,7 @@ namespace UVOCBot.Commands
 {
     [Description("Commands that help with generating team lists")]
     [RequireGuild]
-    public class TeamsModule : BaseCommandModule
+    public class TeamGenerationModule : BaseCommandModule
     {
         [Command("random-teams")]
         [Aliases("rt", "random")]

--- a/UVOCBot/Extensions/CommandContextExtensions.cs
+++ b/UVOCBot/Extensions/CommandContextExtensions.cs
@@ -1,0 +1,28 @@
+﻿using DSharpPlus.Entities;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.CommandsNext
+{
+    public static class CommandContextExtensions
+    {
+        public static async Task<DiscordMessage> RespondWithErrorAsync(this CommandContext ctx, string message)
+        {
+            DiscordEmbedBuilder embed = new()
+            {
+                Color = DiscordColor.Red,
+                Description = message
+            };
+            return await ctx.RespondAsync(embed.Build()).ConfigureAwait(false);
+        }
+
+        public static async Task<DiscordMessage> RespondWithSuccessAsync(this CommandContext ctx, string message)
+        {
+            DiscordEmbedBuilder embed = new()
+            {
+                Color = DiscordColor.Green,
+                Description = message
+            };
+            return await ctx.RespondAsync(embed.Build()).ConfigureAwait(false);
+        }
+    }
+}

--- a/UVOCBot/Extensions/DiscordRoleExtensions.cs
+++ b/UVOCBot/Extensions/DiscordRoleExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.Entities
+{
+    public static class DiscordRoleExtensions
+    {
+        /// <summary>
+        /// Gets all members of a guild who have the specified role
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <param name="role"></param>
+        /// <returns></returns>
+        public static async Task<List<DiscordMember>> GetMembers(this DiscordRole role, DiscordGuild guild)
+        {
+            IReadOnlyCollection<DiscordMember> guildMembers = await guild.GetAllMembersAsync().ConfigureAwait(false);
+            List<DiscordMember> roleOwners = new List<DiscordMember>();
+
+            foreach (DiscordMember member in guildMembers)
+            {
+                if (member.Roles.Contains(role))
+                    roleOwners.Add(member);
+            }
+
+            return roleOwners;
+        }
+    }
+}

--- a/UVOCBot/Extensions/MemberReturnedInfo.cs
+++ b/UVOCBot/Extensions/MemberReturnedInfo.cs
@@ -7,7 +7,7 @@ namespace UVOCBot.Extensions
         public enum GetMemberStatus
         {
             /// <summary>
-            /// The guild member was successfully received
+            /// The guild member was successfully retrieved
             /// </summary>
             Success = 0,
 
@@ -17,7 +17,7 @@ namespace UVOCBot.Extensions
             GuildNotFound = 1,
 
             /// <summary>
-            /// Fetching the channel failed
+            /// The guild member could not be retrieved
             /// </summary>
             Failure = 2
         }

--- a/UVOCBot/Services/IApiService.cs
+++ b/UVOCBot/Services/IApiService.cs
@@ -98,5 +98,27 @@ namespace UVOCBot.Services
         Task DeletePlanetsideSettings(ulong id);
 
         #endregion
+
+        #region MemberGroups
+
+        [Get("/membergroup/{id}")]
+        Task<MemberGroupDTO> GetMemberGroup(ulong id);
+
+        [Get("/membergroup")]
+        Task<MemberGroupDTO> GetMemberGroup(ulong guildId, string groupName);
+
+        [Put("/membergroup/{id}")]
+        Task UpdateMemberGroup(ulong id, MemberGroupDTO group);
+
+        [Post("/membergroup")]
+        Task<MemberGroupDTO> CreateMemberGroup(MemberGroupDTO group);
+
+        [Delete("/membergroup/{id}")]
+        Task DeleteMemberGroup(ulong id);
+
+        [Delete("/membergroup")]
+        Task DeleteMemberGroup(ulong guildId, string groupName);
+
+        #endregion
     }
 }

--- a/UVOCBot/Services/IApiService.cs
+++ b/UVOCBot/Services/IApiService.cs
@@ -107,6 +107,9 @@ namespace UVOCBot.Services
         [Get("/membergroup")]
         Task<MemberGroupDTO> GetMemberGroup(ulong guildId, string groupName);
 
+        [Get("/membergroup/guildgroups/{guildId}")]
+        Task<List<MemberGroupDTO>> GetAllGuildMemberGroups(ulong guildId);
+
         [Put("/membergroup/{id}")]
         Task UpdateMemberGroup(ulong id, MemberGroupDTO group);
 

--- a/UVOCBot/UVOCBot.csproj
+++ b/UVOCBot/UVOCBot.csproj
@@ -17,17 +17,17 @@
 
   <ItemGroup>
     <PackageReference Include="DaybreakGames.Census" Version="3.1.0" />
-    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00801" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00801" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-nightly-00801" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00805" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00805" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-nightly-00805" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="5.0.1" />
-    <PackageReference Include="Refit" Version="6.0.15" />
+    <PackageReference Include="Refit" Version="6.0.24" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.11" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.23" />
     <PackageReference Include="TweetinviAPI" Version="5.0.3" />
   </ItemGroup>
 

--- a/UVOCBot/Workers/TwitterWorker.cs
+++ b/UVOCBot/Workers/TwitterWorker.cs
@@ -11,6 +11,7 @@ using Tweetinvi.Models;
 using Tweetinvi.Parameters;
 using UVOCBot.Config;
 using UVOCBot.Core.Model;
+using UVOCBot.Extensions;
 using UVOCBot.Model;
 using UVOCBot.Services;
 using UVOCBot.Utils;
@@ -165,7 +166,7 @@ namespace UVOCBot.Workers
 
         private async Task PostTweetsToChannelAsync(GuildTwitterSettingsDTO settings, List<ITweet> tweets)
         {
-            ChannelReturnedInfo channelInfo = DiscordClientUtils.TryGetGuildChannel(_discordClient, settings.GuildId, settings.RelayChannelId);
+            ChannelReturnedInfo channelInfo = _discordClient.TryGetGuildChannel(settings.GuildId, settings.RelayChannelId);
 
             switch (channelInfo.Status)
             {


### PR DESCRIPTION
This PR implements a grouping feature, that allows temporary collections of members to be created. Groups are automatically expired after 24hrs, and may contain a maximum of 50 members.

Relevant models (`MemberGroup`, `MemberGroupDTO`) and controllers have been added.
❗ A `CleanupWorker` has been added to the API project. Currently, it checks every 15m whether a group needs to be removed. This breaks the philosphy that the API should simply act as a storage/retrieval layer for data, as it makes far more sense to perform this work locally instead of transferring every group to the client.

The following commands are currently implemented:
- `create <groupName> [members...]`
- `delete <groupName>`
- `list`: Lists all the groups created within that guild
- `info <groupName>`: Gets information about a group, such as creator, expiry time and members