### PR TITLE
Improve pop command and minor fixes to move+bonk commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Release v0.1.2 - 27/03/2021
+
+- Fix a NullReferenceException that occurs when using the `bonk` command on a member not currently in a voice channel
+- Hide the bonk command
+- Remove the exception testing command
+- Fix the `move` commands to reliably move *everyone* in the channel
+- Improve the `population` command to include total and NS pop values, along with attribution to https://ps2.fisu.pw
+
 ## Release v0.1.1 - 14/03/2021
 
 - Implemented a member grouping system for guilds. The following commands are utilised:

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -105,7 +105,7 @@ namespace UVOCBot.Commands
             await ctx.TriggerTypingAsync().ConfigureAwait(false);
 
             // Limit command abuse by making sure the user is actively in the voice channel
-            if (ctx.Member.VoiceState.Channel is null)
+            if (ctx.Member.VoiceState is null || ctx.Member.VoiceState.Channel is null)
             {
                 await ctx.RespondAsync("You must be in a voice channel to use this command").ConfigureAwait(false);
                 return;

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -97,6 +97,7 @@ namespace UVOCBot.Commands
         }
 
         [Command("bonk")]
+        [Hidden]
         [Aliases("goToHornyJail")]
         [Description("Sends a voice member to horny jail")]
         [RequireGuild]
@@ -111,17 +112,17 @@ namespace UVOCBot.Commands
                 return;
             }
 
-            // Ensure that the target is part of the same voice channel as the sender
-            if (!memberToBonk.VoiceState.Channel.Equals(ctx.Member.VoiceState.Channel))
-            {
-                await ctx.RespondAsync("Bonking can only be used on members in the same voice channel").ConfigureAwait(false);
-                return;
-            }
-
             // Check for permission to move members out of the current channel
             if (!ctx.Member.VoiceState.Channel.MemberHasPermissions(Permissions.MoveMembers, ctx.Guild.CurrentMember, ctx.Member))
             {
                 await ctx.RespondAsync("Either you or I do not have permissions to move members from your current channel").ConfigureAwait(false);
+                return;
+            }
+
+            // Ensure that the target is part of the same voice channel as the sender
+            if (!memberToBonk.VoiceState.Channel.Equals(ctx.Member.VoiceState.Channel))
+            {
+                await ctx.RespondAsync("Bonking can only be used on members in the same voice channel").ConfigureAwait(false);
                 return;
             }
 
@@ -155,6 +156,7 @@ namespace UVOCBot.Commands
         }
 
         [Command("bonk-channel")]
+        [Hidden]
         [Description("Sets the voice channel for the bonk command")]
         [RequireGuild]
         public async Task BonkCommand(CommandContext ctx, [Description("The voice channel to send members to when they are bonked")] DiscordChannel bonkChannel)

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -58,7 +58,7 @@ namespace UVOCBot.Commands
                 },
                 Author = new DiscordEmbedBuilder.EmbedAuthor()
                 {
-                    Name = "Written by Carl, A.K.A FalconEye",
+                    Name = "Written by FalconEye",
                     Url = "https://github.com/carlst99",
                     IconUrl = "https://cdn.discordapp.com/avatars/165629177221873664/c1bb057dd76dfec6ed8c2de62dc1c185.png"
                 },

--- a/UVOCBot/Commands/GeneralModule.cs
+++ b/UVOCBot/Commands/GeneralModule.cs
@@ -196,13 +196,6 @@ namespace UVOCBot.Commands
             builder.AddField("TestInlineFieldName2", "TestInlineFieldValue2", true);
             await ctx.RespondAsync(embed: builder.Build()).ConfigureAwait(false);
         }
-
-        [Command("throw-exception")]
-        [RequireOwner]
-        public Task ThrowExceptionCommand(CommandContext ctx)
-        {
-            throw new Exception();
-        }
 #endif
     }
 }

--- a/UVOCBot/Commands/MovementModule.cs
+++ b/UVOCBot/Commands/MovementModule.cs
@@ -18,7 +18,7 @@ namespace UVOCBot.Commands
     [RequireGuild]
     public class MovementModule : BaseCommandModule
     {
-        private static readonly Dictionary<int, string> INT_TO_EMOJI_STRING_TABLE = new Dictionary<int, string>
+        private static readonly Dictionary<int, string> INT_TO_EMOJI_STRING_TABLE = new()
         {
             { 1, ":one:" },
             { 2, ":two:" },
@@ -27,7 +27,7 @@ namespace UVOCBot.Commands
             { 5, ":five:" }
         };
 
-        private static readonly Dictionary<string, int> EMOJI_STRING_TO_INT_TABLE = new Dictionary<string, int>
+        private static readonly Dictionary<string, int> EMOJI_STRING_TO_INT_TABLE = new()
         {
             { ":one:", 1 },
             { ":two:", 2 },
@@ -143,9 +143,12 @@ namespace UVOCBot.Commands
                     return channel;
             }
 
-            IEnumerable<DiscordChannel> validChannels = ctx.Guild.Channels.Values.Where(c => c.Name.StartsWith(channelName)
-                && c.Type == ChannelType.Voice
-                && c.MemberHasPermissions(Permissions.MoveMembers, ctx.Member, ctx.Guild.CurrentMember));
+            IEnumerable<DiscordChannel> validChannels = ctx.Guild.Channels.Values.Where(c =>
+            {
+                return c.Name.Contains(channelName, System.StringComparison.OrdinalIgnoreCase)
+                    && c.Type == ChannelType.Voice
+                    && c.MemberHasPermissions(Permissions.MoveMembers, ctx.Member, ctx.Guild.CurrentMember);
+            });
 
             int channelCount = validChannels.Count();
             if (channelCount == 0)

--- a/UVOCBot/Commands/MovementModule.cs
+++ b/UVOCBot/Commands/MovementModule.cs
@@ -54,7 +54,8 @@ namespace UVOCBot.Commands
             if (moveToChannel is null)
                 return;
 
-            foreach (DiscordMember user in ctx.Member.VoiceState.Channel.Users)
+            DiscordChannel channel = ctx.Guild.GetChannel(ctx.Member.VoiceState.Channel.Id);
+            foreach (DiscordMember user in channel.Users)
                 await moveToChannel.PlaceMemberAsync(user).ConfigureAwait(false);
 
             await ctx.RespondAsync(":white_check_mark:").ConfigureAwait(false);
@@ -76,7 +77,7 @@ namespace UVOCBot.Commands
                 return;
 
             foreach (DiscordMember user in moveFromChannel.Users)
-                await moveToChannel.PlaceMemberAsync(user).ConfigureAwait(false);
+                await user.PlaceInAsync(moveToChannel).ConfigureAwait(false);
 
             await ctx.RespondAsync(":white_check_mark:").ConfigureAwait(false);
         }
@@ -99,9 +100,11 @@ namespace UVOCBot.Commands
                 return;
 
             List<DiscordMember> groupMembers = await TryGetGroupMembersAsync(ctx, groupName).ConfigureAwait(false);
+            DiscordChannel moveFromChannel = ctx.Guild.GetChannel(ctx.Member.VoiceState.Channel.Id);
+
             foreach (DiscordMember member in groupMembers)
             {
-                if (ctx.Member.VoiceState.Channel.Users.Contains(member))
+                if (moveFromChannel.Users.Contains(member))
                     await member.PlaceInAsync(moveToChannel).ConfigureAwait(false);
             }
 
@@ -138,7 +141,7 @@ namespace UVOCBot.Commands
         {
             if (ulong.TryParse(channelName, out ulong channelId) && ctx.Guild.Channels.ContainsKey(channelId))
             {
-                DiscordChannel channel = ctx.Guild.Channels[channelId];
+                DiscordChannel channel = ctx.Guild.GetChannel(channelId);
                 if (channel.Type == ChannelType.Voice && channel.MemberHasPermissions(Permissions.MoveMembers, ctx.Member, ctx.Guild.CurrentMember))
                     return channel;
             }

--- a/UVOCBot/Commands/PlanetsideModule.cs
+++ b/UVOCBot/Commands/PlanetsideModule.cs
@@ -69,17 +69,22 @@ namespace UVOCBot.Commands
                 };
             }
 
-            DiscordEmbedBuilder builder = new DiscordEmbedBuilder()
+            DiscordEmbedBuilder builder = new()
             {
                 Color = Program.DEFAULT_EMBED_COLOUR,
                 Description = await GetWorldStatusString(world).ConfigureAwait(false),
                 Timestamp = DateTimeOffset.UtcNow,
-                Title = world.ToString()
+                Title = world.ToString() + " - " + population.Total.ToString(),
+                Footer = new DiscordEmbedBuilder.EmbedFooter
+                {
+                    Text = "Data gratefully taken from ps2.fisu.pw"
+                }
             };
 
             builder.AddField($":purple_circle: VS - {population.VS}", GetPopulationBar(population.VS));
             builder.AddField($":blue_circle: NC - {population.NC}", GetPopulationBar(population.NC));
             builder.AddField($":red_circle: TR - {population.TR}", GetPopulationBar(population.TR));
+            builder.AddField($":white_circle: NS - {population.NS}", GetPopulationBar(population.NS));
 
             await ctx.RespondAsync(embed: builder.Build()).ConfigureAwait(false);
         }

--- a/UVOCBot/Model/Planetside/FisuPopulation.cs
+++ b/UVOCBot/Model/Planetside/FisuPopulation.cs
@@ -20,5 +20,6 @@ namespace UVOCBot.Model.Planetside
         public int NC => Result[0].NC;
         public int TR => Result[0].TR;
         public int NS => Result[0].NS;
+        public int Total => VS + NC + TR + NS;
     }
 }

--- a/UVOCBot/UVOCBot.csproj
+++ b/UVOCBot/UVOCBot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <UserSecretsId>dotnet-UVOCBot-50875F72-6188-46E3-AAD3-240E24100BB5</UserSecretsId>
   </PropertyGroup>
 


### PR DESCRIPTION
- Fix a NullReferenceException that occurs when using the `bonk` command on a member not currently in a voice channel
- Hide the bonk command
- Remove the exception testing command
- Fix the `move` commands to reliably move *everyone* in the channel
- Improve the `population` command to include total and NS pop values, along with attribution to https://ps2.fisu.pw