### PR TITLE
New Feature: World Status Command

### DIFF
--- a/UVOCBot/Commands/GeneralCommands.cs
+++ b/UVOCBot/Commands/GeneralCommands.cs
@@ -19,8 +19,8 @@ namespace UVOCBot.Commands
 {
     public class GeneralCommands : CommandGroup
     {
-        public const string RELEASE_NOTES = "• **Welcome messages** - Welcome new members, give them roles and take guesses at their PlanetSide 2 character name." +
-            "\r\n• *I am speed* - most commands should now complete faster.";
+        public const string RELEASE_NOTES = "• **World `status` Command** - Check the territory control and status of a world and it's continents." +
+            "\r\n• Made the `population` command faster.";
 
         private readonly ICommandContext _context;
         private readonly MessageResponseHelpers _responder;

--- a/UVOCBot/Commands/Utilities/ExecutionEventService.cs
+++ b/UVOCBot/Commands/Utilities/ExecutionEventService.cs
@@ -24,7 +24,7 @@ namespace UVOCBot.Commands
             {
                 Result res = await _responder.TriggerTypingAsync(context, ct).ConfigureAwait(false);
                 if (!res.IsSuccess)
-                    _logger.LogWarning("Failed to show typing indicator: {message}", res.Unwrap());
+                    _logger.LogWarning("Failed to show typing indicator: {message}", res.Error);
             }
 
             // Always return a successful value. We're not too worried about a failure to show the typing indicator, although we do log it

--- a/UVOCBot/Model/Census/Faction.cs
+++ b/UVOCBot/Model/Census/Faction.cs
@@ -1,0 +1,11 @@
+﻿namespace UVOCBot.Model.Census
+{
+    public enum Faction
+    {
+        None = 0,
+        NC = 1,
+        TR = 2,
+        VS = 3,
+        NSO = 4
+    }
+}

--- a/UVOCBot/Model/Census/Map.cs
+++ b/UVOCBot/Model/Census/Map.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace UVOCBot.Model.Census
+{
+    /// <summary>
+    /// The query model for https://census.daybreakgames.com/s:WVWCeOP4oeLb/get/ps2/map?world_id=1&zone_ids=2,4,6,8
+    /// </summary>
+    public record Map
+    {
+        public record RegionModel
+        {
+            public record RowDataModel
+            {
+                public int RegionId { get; init; }
+                public Faction FactionId { get; init; }
+            }
+
+            public bool IsList { get; init; }
+            public IEnumerable<RowDataModel> Row { get; init; }
+
+            public RegionModel()
+            {
+                Row = new List<RowDataModel>();
+            }
+        }
+
+        public ZoneType ZoneId { get; init; }
+        public RegionModel Regions { get; init; }
+    }
+}

--- a/UVOCBot/Model/Census/Map.cs
+++ b/UVOCBot/Model/Census/Map.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace UVOCBot.Model.Census
 {
@@ -9,22 +10,47 @@ namespace UVOCBot.Model.Census
     {
         public record RegionModel
         {
-            public record RowDataModel
+            public record RowModel
             {
-                public int RegionId { get; init; }
-                public Faction FactionId { get; init; }
+                public record RowDataModel
+                {
+                    [JsonPropertyName("RegionId")]
+                    public int RegionId { get; init; }
+
+                    [JsonPropertyName("FactionId")]
+                    public Faction FactionId { get; init; }
+                }
+
+                [JsonPropertyName("RowData")]
+                public RowDataModel RowData { get; init; }
+
+                public RowModel()
+                {
+                    RowData = new RowDataModel();
+                }
             }
 
+            [JsonPropertyName("IsList")]
             public bool IsList { get; init; }
-            public IEnumerable<RowDataModel> Row { get; init; }
+
+            [JsonPropertyName("Row")]
+            public List<RowModel> Row { get; init; }
 
             public RegionModel()
             {
-                Row = new List<RowDataModel>();
+                Row = new List<RowModel>();
             }
         }
 
+        [JsonPropertyName("ZoneId")]
         public ZoneType ZoneId { get; init; }
+
+        [JsonPropertyName("Regions")]
         public RegionModel Regions { get; init; }
+
+        public Map()
+        {
+            Regions = new RegionModel();
+        }
     }
 }

--- a/UVOCBot/Model/Census/MetagameEvent.cs
+++ b/UVOCBot/Model/Census/MetagameEvent.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace UVOCBot.Model.Census
+{
+    /// <summary>
+    /// The query model for https://census.daybreakgames.com/get/ps2/world_event?type=METAGAME&world_id=1&c:limit=20&c:sort=timestamp&c:join=world%5Einject_at:world
+    /// </summary>
+    public record MetagameEvent
+    {
+        public int MetagameEventId { get; init; }
+        public int MetagameEventState { get; init; }
+        public double FactionNC { get; init; }
+        public double FactionTR { get; init; }
+        public double FactionVS { get; init; }
+        public int ExperienceBonus { get; init; }
+        public DateTimeOffset Timestamp { get; init; }
+        public ZoneType ZoneId { get; init; }
+        public WorldType WorldId { get; init; }
+        public int InstanceId { get; init; }
+        public string MetagameEventStateName { get; init; }
+        public World World { get; init; }
+
+        public MetagameEvent()
+        {
+            MetagameEventStateName = string.Empty;
+            World = new World();
+        }
+    }
+}

--- a/UVOCBot/Model/Census/ZoneType.cs
+++ b/UVOCBot/Model/Census/ZoneType.cs
@@ -5,7 +5,6 @@
         Indar = 2,
         Hossin = 4,
         Amerish = 6,
-        Esamir = 8,
-        Koltyr = 14
+        Esamir = 8
     }
 }

--- a/UVOCBot/Model/Census/ZoneType.cs
+++ b/UVOCBot/Model/Census/ZoneType.cs
@@ -5,6 +5,7 @@
         Indar = 2,
         Hossin = 4,
         Amerish = 6,
-        Esamir = 8
+        Esamir = 8,
+        Koltyr = 14
     }
 }

--- a/UVOCBot/Program.cs
+++ b/UVOCBot/Program.cs
@@ -240,7 +240,7 @@ namespace UVOCBot
 
             if (!slashCommandsSupported.IsSuccess)
             {
-                Log.Error("The registered commands of the bot aren't supported as slash commands: {reason}", slashCommandsSupported.Unwrap().Message);
+                Log.Error("The registered commands of the bot aren't supported as slash commands: {reason}", slashCommandsSupported.Error);
             }
             else
             {

--- a/UVOCBot/Services/Abstractions/ICensusApiService.cs
+++ b/UVOCBot/Services/Abstractions/ICensusApiService.cs
@@ -56,5 +56,13 @@ namespace UVOCBot.Services.Abstractions
         /// <param name="ct">A <see cref="CancellationToken"/> to stop the operation with.</param>
         /// <returns></returns>
         Task<List<NewOutfitMember>> GetNewOutfitMembersAsync(ulong outfitId, uint limit, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the most recent metagame events for a world.
+        /// </summary>
+        /// <param name="world">The world to retrieve events for.</param>
+        /// <param name="ct">A <see cref="CancellationToken"/> used to stop the operation.</param>
+        /// <returns>A list of metagame events.</returns>
+        Task<List<MetagameEvent>> GetMetagameEventsAsync(WorldType world, CancellationToken ct = default);
     }
 }

--- a/UVOCBot/Services/Abstractions/ICensusApiService.cs
+++ b/UVOCBot/Services/Abstractions/ICensusApiService.cs
@@ -64,5 +64,14 @@ namespace UVOCBot.Services.Abstractions
         /// <param name="ct">A <see cref="CancellationToken"/> used to stop the operation.</param>
         /// <returns>A list of metagame events.</returns>
         Task<List<MetagameEvent>> GetMetagameEventsAsync(WorldType world, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the maps for a world.
+        /// </summary>
+        /// <param name="world">The world to retrieve the maps for.</param>
+        /// <param name="zones">The zones to retrieve maps for.</param>
+        /// <param name="ct">A <see cref="CancellationToken"/> used to stop the operation.</param>
+        /// <returns>A list of maps.</returns>
+        Task<List<Map>> GetMaps(WorldType world, IEnumerable<ZoneType> zones, CancellationToken ct = default);
     }
 }

--- a/UVOCBot/Services/ApiServiceBase.cs
+++ b/UVOCBot/Services/ApiServiceBase.cs
@@ -26,8 +26,12 @@ namespace UVOCBot.Services
 
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
-                _logger.LogError(response.ErrorException, "Failed to execute database API operation: {exception}", response.ErrorMessage);
-                return Result<T>.FromError(response.ErrorException);
+                Exception ex = new($"API query failed with message { response.ErrorMessage }. Response status: { response.ResponseStatus }");
+                if (response.ErrorException is not null)
+                    ex = response.ErrorException;
+
+                _logger.LogError(ex, "Failed to execute API operation with status {status} and reason {message}", response.ResponseStatus, response.ErrorMessage);
+                return ex;
             }
 
             if (request.Method == Method.GET && response.StatusCode == HttpStatusCode.OK)
@@ -45,8 +49,12 @@ namespace UVOCBot.Services
 
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
-                _logger.LogError(response.ErrorException, "Failed to execute database API operation: {exception}", response.ErrorMessage);
-                return Result.FromError(new ExceptionError(response.ErrorException));
+                Exception ex = new($"API query failed with message { response.ErrorMessage }. Response status: { response.ResponseStatus }");
+                if (response.ErrorException is not null)
+                    ex = response.ErrorException;
+
+                _logger.LogError(ex, "Failed to execute API operation with {status} and reason {message}", response.ResponseStatus, response.ErrorMessage);
+                return ex;
             }
 
             if (response.StatusCode != HttpStatusCode.NoContent)

--- a/UVOCBot/Services/CensusApiService.cs
+++ b/UVOCBot/Services/CensusApiService.cs
@@ -1,4 +1,5 @@
 ﻿using DbgCensus.Core.Exceptions;
+using DbgCensus.Core.Utils;
 using DbgCensus.Rest.Abstractions;
 using DbgCensus.Rest.Abstractions.Queries;
 using Microsoft.Extensions.Logging;
@@ -27,6 +28,9 @@ namespace UVOCBot.Services
             _queryFactory = censusQueryFactory;
             _censusClient = censusClient;
         }
+
+        // TODO: No result exception
+        // TODO: Caching
 
         // TODO: Convert to standard model
 
@@ -97,7 +101,7 @@ namespace UVOCBot.Services
         {
             IQueryBuilder query = _queryFactory.Get()
                 .OnCollection("outfit")
-                .Where("outfit_id", SearchModifier.Equals, outfitIds);
+                .WhereAll("outfit_id", SearchModifier.Equals, outfitIds);
 
             ConstructOnlineMembersQuery(query);
 
@@ -148,7 +152,7 @@ namespace UVOCBot.Services
             IQueryBuilder query = _queryFactory.Get()
                 .OnCollection("map")
                 .Where("world_id", SearchModifier.Equals, (int)world)
-                .Where("zone_ids", SearchModifier.Equals, zones.Cast<int>());
+                .WhereAll("zone_ids", SearchModifier.Equals, zones.Select(z => (int)z));
 
             return await GetListAsync<Map>(query, ct).ConfigureAwait(false);
         }

--- a/UVOCBot/UVOCBot.csproj
+++ b/UVOCBot/UVOCBot.csproj
@@ -26,22 +26,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbgCensus.Rest" Version="1.0.0-beta.5" />
+    <PackageReference Include="DbgCensus.Rest" Version="1.0.0-beta.8" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="5.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
-    <PackageReference Include="Remora.Discord" Version="3.0.34" />
-    <PackageReference Include="Remora.Discord.Caching" Version="8.0.1" />
-    <PackageReference Include="Remora.Discord.Commands" Version="3.10.13" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
-    <PackageReference Include="RestSharp.Serializers.SystemTextJson" Version="106.11.7" />
+    <PackageReference Include="Remora.Discord" Version="3.0.37" />
+    <PackageReference Include="Remora.Discord.Caching" Version="8.0.4" />
+    <PackageReference Include="Remora.Discord.Commands" Version="4.0.2" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="RestSharp.Serializers.SystemTextJson" Version="106.12.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.0.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.38" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.41" />
     <PackageReference Include="TweetinviAPI" Version="5.0.4" />
   </ItemGroup>
 

--- a/UVOCBot/UVOCBot.csproj
+++ b/UVOCBot/UVOCBot.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbgCensus.Rest" Version="1.0.0-beta.8" />
+    <PackageReference Include="DbgCensus.Rest" Version="1.0.0-beta.10" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="5.0.1" />


### PR DESCRIPTION
- Adds the `status` command, to retrieve the status of a world, and the territory of each continent.
- Removes the world status check from the population command, significantly speeding it up when calls are made that can retrieve the data from cache